### PR TITLE
Add (failing) test for orientation

### DIFF
--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -1,4 +1,5 @@
 import numpy as np
+from scipy.spatial.transform import Rotation as R
 
 
 def test_orientation(baxter_left_arm):
@@ -32,9 +33,23 @@ def test_orientation_full_frame(baxter_left_arm):
     orientation = baxter_left_arm.forward_kinematics(ik)[:3, :3]
 
     # Check
-    np.testing.assert_almost_equal(position, target_position, decimal=5)
-    np.testing.assert_almost_equal(orientation, target_orientation, decimal=5)
+    np.testing.assert_almost_equal(position, target_position, decimal=3)
+    np.testing.assert_almost_equal(orientation, target_orientation, decimal=3)
 
+def test_orientation_no_eye_full_frame(baxter_left_arm):
+    target_position = [0.1, 0.4, -0.1]
+    target_orientation = R.from_euler('xyz', [0, 90, 90], degrees=True).as_matrix()
+
+    # Begin to place the arm in the right position
+    ik = baxter_left_arm.inverse_kinematics(target_position)
+    ik = baxter_left_arm.inverse_kinematics(target_position, target_orientation, initial_position=ik, orientation_mode='all')
+
+    position = baxter_left_arm.forward_kinematics(ik)[:3, 3]
+    orientation = baxter_left_arm.forward_kinematics(ik)[:3, :3]
+
+    # Check
+    np.testing.assert_almost_equal(position, target_position, decimal=3)
+    np.testing.assert_almost_equal(orientation, target_orientation, decimal=3)
 
 def test_orientation_only(baxter_left_arm):
     target_orientation = np.eye(3)


### PR DESCRIPTION
The orientation on full referential only works for me on simple orientations.
If more complex orientations are used, I get either the translation or the rotation wrong.

Here is the result of the adde test:
```
========================================================== FAILURES ==========================================================
_____________________________________________ test_orientation_no_eye_full_frame _____________________________________________

baxter_left_arm = Kinematic chain name=baxter_left_arm links=[Link name=Base link bounds=(None, None), Link name=torso_t0 bounds=(-3.01,...ounds=(None, None)] active_links=[False False False  True  True  True  True  True  True  True  True  True
  True False]

    def test_orientation_no_eye_full_frame(baxter_left_arm):
        target_position = [0.1, 0.4, -0.1]
        target_orientation = R.from_euler('xyz', [0, 90, 90], degrees=True).as_matrix()

        # Begin to place the arm in the right position
        ik = baxter_left_arm.inverse_kinematics(target_position)
        ik = baxter_left_arm.inverse_kinematics(target_position, target_orientation, initial_position=ik, orientation_mode='all')

        position = baxter_left_arm.forward_kinematics(ik)[:3, 3]
        orientation = baxter_left_arm.forward_kinematics(ik)[:3, :3]

        # Check
        np.testing.assert_almost_equal(position, target_position, decimal=3)
>       np.testing.assert_almost_equal(orientation, target_orientation, decimal=3)
E       AssertionError: 
E       Arrays are not almost equal to 3 decimals
E       
E       Mismatched elements: 9 / 9 (100%)
E       Max absolute difference: 1.63527758
E       Max relative difference: 1.63527758
E        x: array([[ 0.56 ,  0.426, -0.71 ],
E              [-0.531,  0.843,  0.086],
E              [ 0.635,  0.329,  0.699]])
E        y: array([[ 0., -1.,  0.],
E              [ 0.,  0.,  1.],
E              [-1.,  0.,  0.]])

test_orientation.py:53: AssertionError
================================================== short test summary info ===================================================
FAILED test_orientation.py::test_orientation_no_eye_full_frame - AssertionError:
================================================ 1 failed, 3 passed in 5.00s =================================================
```