### PR TITLE
Fix continuous joints at import

### DIFF
--- a/src/ikpy/urdf/URDF.py
+++ b/src/ikpy/urdf/URDF.py
@@ -223,9 +223,9 @@ def get_urdf_parameters(urdf_file, base_elements=None, last_link_vector=None, ba
 
         limit = joint.find("limit")
         if limit is not None:
-            if limit.attrib["lower"]:
+            if limit.find("lower") is not None:
                 bounds[0] = float(limit.attrib["lower"])
-            if limit.attrib["upper"]:
+            if limit.find("upper") is not None:
                 bounds[1] = float(limit.attrib["upper"])
 
         parameters.append(lib_link.URDFLink(

--- a/src/ikpy/urdf/URDF.py
+++ b/src/ikpy/urdf/URDF.py
@@ -223,9 +223,9 @@ def get_urdf_parameters(urdf_file, base_elements=None, last_link_vector=None, ba
 
         limit = joint.find("limit")
         if limit is not None:
-            if limit.find("lower") is not None:
+            if "lower" in limit.attrib:
                 bounds[0] = float(limit.attrib["lower"])
-            if limit.find("upper") is not None:
+            if "upper" in limit.attrib:
                 bounds[1] = float(limit.attrib["upper"])
 
         parameters.append(lib_link.URDFLink(


### PR DESCRIPTION
The check before threw an error, when a joint had no limits. This fixes this issue. To test this, try importing a urdf file, where a continuous joint has torque limit, but no lower and upper limit