### PR TITLE
Support for modified DH

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ With IKPy, you can:
 * IKPy is **precise** (up to 7 digits): the only limitation being your underlying model's precision, and **fast**: from 7 ms to 50 ms (depending on your precision) for a complete IK computation.
 * **Plot** your kinematic chain: no need to use a real robot (or a simulator) to test your algorithms!
 * Define your own Inverse Kinematics methods.
+* Support for both modified and classical Denavit-Hartenberg parameters 
 * Utils to parse and analyze URDF files:
 
 ![](./tutorials/assets/baxter_tree.png)

--- a/src/ikpy/link.py
+++ b/src/ikpy/link.py
@@ -270,17 +270,19 @@ class DHLink(Link):
         offset along previous   to the common normal
     use_symbolic_matrix: bool
         whether the transformation matrix is stored as Numpy array or as a Sympy symbolic matrix.
-
+    modified_dh: bool
+        whether to use the modified DH parameters or not
     Returns
     -------
     DHLink:
         The link object
     """
 
-    def __init__(self, name, d=0, a=0, bounds=None, use_symbolic_matrix=True):
+    def __init__(self, name, d=0, a=0, bounds=None, use_symbolic_matrix=True,modified_dh=True):
         Link.__init__(self, use_symbolic_matrix)
         self.d = d
         self.a = a
+        self.modified_dh = modified_dh
 
     def get_link_frame_matrix(self, parameters):
         """ Computes the homogeneous transformation matrix for this link. """
@@ -289,7 +291,12 @@ class DHLink(Link):
         st = np.sin(theta + self.theta)
         ca = np.cos(self.alpha)
         sa = np.sin(self.alpha)
-
+        if self.modified_dh:
+            return np.matrix(((ct, -st, 0, self.a),
+                              (st * ca, ct * ca, -sa, -self.d * sa),
+                              (st * sa, ct * sa, ca, self.d * ca),
+                              (0, 0, 0, 1)))
+        
         return np.matrix(((ct, -st * ca, st * sa, self.a * ct),
                           (st, ct * ca, -ct * sa, self.a * st),
                           (0, sa, ca, self.d),


### PR DESCRIPTION
The library was using classical as default added and had no support for modified Denavit–Hartenberg parameters (DH parameters) made modified dh as default(since its usage has increased nowdays) and also allowed the user to choose between the two.