### PR TITLE
Jax backend

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires=
 
 [options.extras_require]
 plot = matplotlib; graphviz
+jax = jax; jaxlib
 
 [options.packages.find]
 where=src

--- a/src/ikpy/__init__.py
+++ b/src/ikpy/__init__.py
@@ -1,3 +1,11 @@
 from ._version import __version__
 
-__all__ = ["__version__"]
+# Check for JAX availability
+try:
+    import jax
+    from . import jax_backend
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+
+__all__ = ["__version__", "JAX_AVAILABLE"]

--- a/src/ikpy/__init__.py
+++ b/src/ikpy/__init__.py
@@ -2,8 +2,8 @@ from ._version import __version__
 
 # Check for JAX availability
 try:
-    import jax
-    from . import jax_backend
+    import jax  # noqa: F401
+    from . import jax_backend  # noqa: F401
     JAX_AVAILABLE = True
 except ImportError:
     JAX_AVAILABLE = False

--- a/src/ikpy/chain.py
+++ b/src/ikpy/chain.py
@@ -209,11 +209,13 @@ class Chain:
             Optional : the initial position of each joint of the chain. Defaults to 0 for each joint
         backend: str
             The computational backend to use: "numpy" (default) or "jax".
-            The JAX backend uses automatic differentiation for gradient computation.
+            The JAX backend uses scipy least_squares with analytical Jacobian via autodiff.
             For JAX, additional kwargs are supported:
-            * optimizer: "scipy" (default), "adam", or "gradient_descent"
-            * learning_rate: float (default: 0.05, for adam/gradient_descent)
             * tol: float (default: 1e-6)
+            * use_analytical_jacobian: bool (default: True)
+            * scipy_method: 'trf' (default), 'dogbox', or 'lm'
+            * scipy_x_scale: 'jac' (default) for auto-scaling
+            * scipy_loss: 'linear' (default), 'soft_l1', 'huber', etc.
         kwargs: See ikpy.inverse_kinematics.inverse_kinematic_optimization
 
         Returns
@@ -233,16 +235,15 @@ class Chain:
         if backend == "jax":
             # Extract JAX-specific kwargs
             jax_kwargs = {}
-            jax_specific_keys = ['optimizer', 'learning_rate', 'tol']
+            jax_specific_keys = ['tol', 'use_analytical_jacobian', 'scipy_method', 
+                                 'scipy_x_scale', 'scipy_loss', 'scipy_gtol', 
+                                 'scipy_max_nfev', 'scipy_tr_solver', 'scipy_tr_options',
+                                 'scipy_verbose']
             for key in jax_specific_keys:
                 if key in kwargs:
                     jax_kwargs[key] = kwargs.pop(key)
 
             # Map common kwargs
-            if 'max_iter' in kwargs:
-                jax_kwargs['max_iter'] = kwargs.pop('max_iter')
-            if 'regularization_parameter' in kwargs:
-                jax_kwargs['regularization_parameter'] = kwargs.pop('regularization_parameter')
             if 'orientation_mode' in kwargs:
                 jax_kwargs['orientation_mode'] = kwargs.pop('orientation_mode')
             if 'no_position' in kwargs:

--- a/src/ikpy/chain.py
+++ b/src/ikpy/chain.py
@@ -235,8 +235,8 @@ class Chain:
         if backend == "jax":
             # Extract JAX-specific kwargs
             jax_kwargs = {}
-            jax_specific_keys = ['tol', 'use_analytical_jacobian', 'scipy_method', 
-                                 'scipy_x_scale', 'scipy_loss', 'scipy_gtol', 
+            jax_specific_keys = ['tol', 'use_analytical_jacobian', 'scipy_method',
+                                 'scipy_x_scale', 'scipy_loss', 'scipy_gtol',
                                  'scipy_max_nfev', 'scipy_tr_solver', 'scipy_tr_options',
                                  'scipy_verbose']
             for key in jax_specific_keys:

--- a/src/ikpy/inverse_kinematics.py
+++ b/src/ikpy/inverse_kinematics.py
@@ -3,6 +3,14 @@ import scipy.optimize
 import numpy as np
 from . import logs
 
+# Check for JAX availability
+try:
+    import jax
+    import jax.numpy as jnp
+    JAX_AVAILABLE = True
+except ImportError:
+    JAX_AVAILABLE = False
+
 
 ORIENTATION_COEFF = 1.
 

--- a/src/ikpy/inverse_kinematics.py
+++ b/src/ikpy/inverse_kinematics.py
@@ -5,8 +5,8 @@ from . import logs
 
 # Check for JAX availability
 try:
-    import jax
-    import jax.numpy as jnp
+    import jax  # noqa: F401
+    import jax.numpy as jnp  # noqa: F401
     JAX_AVAILABLE = True
 except ImportError:
     JAX_AVAILABLE = False

--- a/src/ikpy/jax_backend.py
+++ b/src/ikpy/jax_backend.py
@@ -1,0 +1,636 @@
+# coding= utf8
+"""
+.. module:: jax_backend
+This module implements JAX-based forward and inverse kinematics.
+JAX enables automatic differentiation and JIT compilation for faster computation.
+"""
+import jax
+import jax.numpy as jnp
+from jax import jit
+from functools import partial
+import numpy as np
+
+from ikpy.utils import jax_geometry as geom
+
+
+# Check if JAX is available
+JAX_AVAILABLE = True
+
+
+def extract_chain_parameters(chain):
+    """
+    Extract chain parameters into JAX-compatible arrays.
+
+    Parameters
+    ----------
+    chain: ikpy.chain.Chain
+        The kinematic chain
+
+    Returns
+    -------
+    dict
+        Dictionary containing all link parameters as JAX arrays
+    """
+    n_links = len(chain.links)
+
+    # Initialize arrays
+    origin_translations = []
+    origin_orientations = []
+    rotation_axes = []
+    translation_axes = []
+    joint_types = []  # 0=origin, 1=revolute, 2=prismatic, 3=fixed
+
+    for link in chain.links:
+        if link.__class__.__name__ == "OriginLink":
+            origin_translations.append([0.0, 0.0, 0.0])
+            origin_orientations.append([0.0, 0.0, 0.0])
+            rotation_axes.append([0.0, 0.0, 1.0])
+            translation_axes.append([0.0, 0.0, 0.0])
+            joint_types.append(0)  # Origin link
+        elif link.__class__.__name__ == "URDFLink":
+            origin_translations.append(link.origin_translation.tolist())
+            origin_orientations.append(link.origin_orientation.tolist())
+
+            if link.has_rotation and link.rotation is not None:
+                rotation_axes.append(link.rotation.tolist())
+            else:
+                rotation_axes.append([0.0, 0.0, 1.0])
+
+            if link.has_translation and link.translation is not None:
+                translation_axes.append(link.translation.tolist())
+            else:
+                translation_axes.append([0.0, 0.0, 0.0])
+
+            if link.joint_type == "revolute":
+                joint_types.append(1)
+            elif link.joint_type == "prismatic":
+                joint_types.append(2)
+            else:  # fixed
+                joint_types.append(3)
+        elif link.__class__.__name__ == "DHLink":
+            # DH parameters - will need special handling
+            origin_translations.append([0.0, 0.0, 0.0])
+            origin_orientations.append([0.0, 0.0, 0.0])
+            rotation_axes.append([0.0, 0.0, 1.0])
+            translation_axes.append([0.0, 0.0, 0.0])
+            joint_types.append(4)  # DH link
+        else:
+            raise ValueError(f"Unknown link type: {link.__class__.__name__}")
+
+    return {
+        'origin_translations': jnp.array(origin_translations),
+        'origin_orientations': jnp.array(origin_orientations),
+        'rotation_axes': jnp.array(rotation_axes),
+        'translation_axes': jnp.array(translation_axes),
+        'joint_types': jnp.array(joint_types, dtype=jnp.int32),
+        'n_links': n_links
+    }
+
+
+def compute_single_link_matrix(origin_translation, origin_orientation, rotation_axis,
+                               translation_axis, joint_type, joint_param):
+    """
+    Compute a single link's transformation matrix.
+
+    Parameters
+    ----------
+    origin_translation: jnp.ndarray (3,)
+    origin_orientation: jnp.ndarray (3,)
+    rotation_axis: jnp.ndarray (3,)
+    translation_axis: jnp.ndarray (3,)
+    joint_type: int
+        0=origin, 1=revolute, 2=prismatic, 3=fixed
+    joint_param: float
+        The joint parameter (angle for revolute, displacement for prismatic)
+
+    Returns
+    -------
+    jnp.ndarray (4, 4)
+        The transformation matrix
+    """
+    # Origin link - identity
+    def origin_link(_):
+        return jnp.eye(4)
+
+    # Revolute joint
+    def revolute_link(theta):
+        return geom.compute_link_frame_matrix_revolute(
+            origin_translation, origin_orientation, rotation_axis, theta
+        )
+
+    # Prismatic joint
+    def prismatic_link(mu):
+        return geom.compute_link_frame_matrix_prismatic(
+            origin_translation, origin_orientation, translation_axis, mu
+        )
+
+    # Fixed joint
+    def fixed_link(_):
+        return geom.compute_link_frame_matrix_fixed(origin_translation, origin_orientation)
+
+    # Use lax.switch for conditional selection (JIT-compatible)
+    return jax.lax.switch(
+        joint_type,
+        [origin_link, revolute_link, prismatic_link, fixed_link],
+        joint_param
+    )
+
+
+def forward_kinematics_jax(joints, chain_params):
+    """
+    Compute forward kinematics using JAX.
+
+    Parameters
+    ----------
+    joints: jnp.ndarray
+        Joint parameters (n_links,)
+    chain_params: dict
+        Chain parameters extracted by extract_chain_parameters
+
+    Returns
+    -------
+    jnp.ndarray (4, 4)
+        The end-effector transformation matrix
+    """
+    frame_matrix = jnp.eye(4)
+
+    def body_fn(i, frame_matrix):
+        link_matrix = compute_single_link_matrix(
+            chain_params['origin_translations'][i],
+            chain_params['origin_orientations'][i],
+            chain_params['rotation_axes'][i],
+            chain_params['translation_axes'][i],
+            chain_params['joint_types'][i],
+            joints[i]
+        )
+        return jnp.dot(frame_matrix, link_matrix)
+
+    frame_matrix = jax.lax.fori_loop(0, chain_params['n_links'], body_fn, frame_matrix)
+    return frame_matrix
+
+
+def forward_kinematics_full_jax(joints, chain_params):
+    """
+    Compute forward kinematics for all links using JAX.
+
+    Parameters
+    ----------
+    joints: jnp.ndarray
+        Joint parameters (n_links,)
+    chain_params: dict
+        Chain parameters extracted by extract_chain_parameters
+
+    Returns
+    -------
+    jnp.ndarray (n_links, 4, 4)
+        Transformation matrices for all links
+    """
+    def scan_fn(frame_matrix, link_idx):
+        link_matrix = compute_single_link_matrix(
+            chain_params['origin_translations'][link_idx],
+            chain_params['origin_orientations'][link_idx],
+            chain_params['rotation_axes'][link_idx],
+            chain_params['translation_axes'][link_idx],
+            chain_params['joint_types'][link_idx],
+            joints[link_idx]
+        )
+        new_frame = jnp.dot(frame_matrix, link_matrix)
+        return new_frame, new_frame
+
+    _, all_frames = jax.lax.scan(scan_fn, jnp.eye(4), jnp.arange(chain_params['n_links']))
+    return all_frames
+
+
+def inverse_kinematics_jax(chain, target_frame, starting_nodes_angles,
+                           regularization_parameter=None, max_iter=100,
+                           orientation_mode=None, no_position=False,
+                           optimizer="L-BFGS-B", learning_rate=0.01, tol=1e-6):
+    """
+    Compute inverse kinematics using JAX's automatic differentiation.
+
+    Parameters
+    ----------
+    chain: ikpy.chain.Chain
+        The kinematic chain
+    target_frame: np.ndarray (4, 4)
+        The target pose
+    starting_nodes_angles: np.ndarray
+        Initial joint angles
+    regularization_parameter: float
+        Regularization coefficient
+    max_iter: int
+        Maximum number of iterations
+    orientation_mode: str
+        One of None, "X", "Y", "Z", "all"
+    no_position: bool
+        If True, don't optimize position
+    optimizer: str
+        Optimizer to use: "L-BFGS-B", "gradient_descent", or "adam"
+    learning_rate: float
+        Learning rate for gradient-based optimizers
+    tol: float
+        Tolerance for convergence
+
+    Returns
+    -------
+    np.ndarray
+        Optimal joint angles
+    """
+    # Extract chain parameters
+    chain_params = extract_chain_parameters(chain)
+
+    # Determine dtype based on JAX configuration
+    # Use float64 if x64 mode is enabled, otherwise float32
+    try:
+        from jax import config
+        use_float64 = config.jax_enable_x64
+    except (ImportError, AttributeError):
+        use_float64 = False
+
+    dtype = jnp.float64 if use_float64 else jnp.float32
+
+    # Convert to JAX arrays with consistent dtype
+    target_frame_jax = jnp.array(target_frame, dtype=dtype)
+    starting_nodes_angles_jax = jnp.array(starting_nodes_angles, dtype=dtype)
+    active_links_mask = jnp.array(chain.active_links_mask)
+
+    # Get bounds for active joints
+    bounds_list = [link.bounds for link in chain.links]
+    lower_bounds = []
+    upper_bounds = []
+    for i, (mask, bounds) in enumerate(zip(chain.active_links_mask, bounds_list)):
+        if mask:
+            lower_bounds.append(bounds[0] if np.isfinite(bounds[0]) else -np.pi * 2)
+            upper_bounds.append(bounds[1] if np.isfinite(bounds[1]) else np.pi * 2)
+    lower_bounds = jnp.array(lower_bounds, dtype=dtype)
+    upper_bounds = jnp.array(upper_bounds, dtype=dtype)
+
+    # Extract active joints from full joints
+    def active_from_full(joints):
+        return joints[active_links_mask]
+
+    # More efficient version using index_update
+    active_indices = jnp.where(active_links_mask)[0]
+
+    def active_to_full_v2(active_joints, initial_position):
+        return initial_position.at[active_indices].set(active_joints)
+
+    # Target position
+    target_position = target_frame_jax[:3, 3]
+
+    # Define loss function
+    def compute_loss(active_joints):
+        # Ensure consistent dtype
+        active_joints = active_joints.astype(dtype)
+
+        # Convert to full joints
+        full_joints = active_to_full_v2(active_joints, starting_nodes_angles_jax)
+
+        # Compute FK
+        fk = forward_kinematics_jax(full_joints, chain_params)
+
+        # Position error
+        if not no_position:
+            position_error = fk[:3, 3] - target_position
+            loss = jnp.sum(position_error ** 2)
+        else:
+            loss = jnp.array(0.0, dtype=dtype)
+
+        # Orientation error
+        if orientation_mode == "X":
+            orientation_error = fk[:3, 0] - target_frame_jax[:3, 0]
+            loss = loss + jnp.sum(orientation_error ** 2)
+        elif orientation_mode == "Y":
+            orientation_error = fk[:3, 1] - target_frame_jax[:3, 1]
+            loss = loss + jnp.sum(orientation_error ** 2)
+        elif orientation_mode == "Z":
+            orientation_error = fk[:3, 2] - target_frame_jax[:3, 2]
+            loss = loss + jnp.sum(orientation_error ** 2)
+        elif orientation_mode == "all":
+            orientation_error = (fk[:3, :3] - target_frame_jax[:3, :3]).ravel()
+            loss = loss + jnp.sum(orientation_error ** 2)
+
+        # Regularization
+        if regularization_parameter is not None:
+            reg_term = regularization_parameter * jnp.sum(
+                (active_joints - active_from_full(starting_nodes_angles_jax)) ** 2
+            )
+            loss = loss + reg_term
+
+        return loss
+
+    # Compute gradient
+    grad_loss = jax.grad(compute_loss)
+
+    # Initial active joints
+    x0 = active_from_full(starting_nodes_angles_jax)
+
+    if optimizer == "L-BFGS-B":
+        # Use scipy optimization through JAX value_and_grad
+        from jax.scipy.optimize import minimize as jax_scipy_minimize
+
+        # Use BFGS from JAX (no bounds support, so we clip manually)
+        def loss_clipped(x):
+            x = x.astype(dtype)
+            x_clipped = jnp.clip(x, lower_bounds, upper_bounds)
+            return compute_loss(x_clipped)
+
+        result = jax_scipy_minimize(loss_clipped, x0, method='BFGS',
+                                    options={'maxiter': max_iter})
+        optimal_active = jnp.clip(result.x, lower_bounds, upper_bounds)
+
+    elif optimizer == "gradient_descent":
+        # Simple gradient descent with bounds
+        x = x0
+        for _ in range(max_iter):
+            g = grad_loss(x)
+            x = x - learning_rate * g
+            x = jnp.clip(x, lower_bounds, upper_bounds)
+
+            # Check convergence
+            if jnp.max(jnp.abs(g)) < tol:
+                break
+        optimal_active = x
+
+    elif optimizer == "adam":
+        # Adam optimizer
+        x = x0
+        m = jnp.zeros_like(x)
+        v = jnp.zeros_like(x)
+        beta1, beta2 = 0.9, 0.999
+        eps = jnp.array(1e-8, dtype=dtype)
+
+        for t in range(1, max_iter + 1):
+            g = grad_loss(x)
+            m = beta1 * m + (1 - beta1) * g
+            v = beta2 * v + (1 - beta2) * g ** 2
+            m_hat = m / (1 - beta1 ** t)
+            v_hat = v / (1 - beta2 ** t)
+            x = x - learning_rate * m_hat / (jnp.sqrt(v_hat) + eps)
+            x = jnp.clip(x, lower_bounds, upper_bounds)
+
+            # Check convergence
+            if jnp.max(jnp.abs(g)) < tol:
+                break
+        optimal_active = x
+
+    else:
+        raise ValueError(f"Unknown optimizer: {optimizer}")
+
+    # Convert back to full joints
+    result = active_to_full_v2(optimal_active, starting_nodes_angles_jax)
+
+    # Convert to numpy for compatibility
+    return np.array(result)
+
+
+def inverse_kinematics_scipy_with_jax_grad(chain, target_frame, starting_nodes_angles,
+                                           regularization_parameter=None, max_iter=None,
+                                           orientation_mode=None, no_position=False,
+                                           optimizer="least_squares"):
+    """
+    Compute inverse kinematics using scipy but with JAX-computed gradients.
+    This provides faster gradient computation while maintaining scipy's robust optimizers.
+
+    Parameters
+    ----------
+    chain: ikpy.chain.Chain
+        The kinematic chain
+    target_frame: np.ndarray (4, 4)
+        The target pose
+    starting_nodes_angles: np.ndarray
+        Initial joint angles
+    regularization_parameter: float
+        Regularization coefficient
+    max_iter: int
+        Maximum iterations (deprecated)
+    orientation_mode: str
+        One of None, "X", "Y", "Z", "all"
+    no_position: bool
+        If True, don't optimize position
+    optimizer: str
+        "least_squares" or "scalar"
+
+    Returns
+    -------
+    np.ndarray
+        Optimal joint angles
+    """
+    import scipy.optimize
+
+    # Extract chain parameters
+    chain_params = extract_chain_parameters(chain)
+
+    # Convert to JAX arrays
+    target_frame_jax = jnp.array(target_frame)
+    starting_nodes_angles_jax = jnp.array(starting_nodes_angles, dtype=jnp.float64)
+    active_links_mask = jnp.array(chain.active_links_mask)
+
+    # Get bounds
+    bounds_list = [link.bounds for link in chain.links]
+    active_bounds = []
+    for mask, bounds in zip(chain.active_links_mask, bounds_list):
+        if mask:
+            active_bounds.append(bounds)
+    active_bounds = np.array(active_bounds)
+
+    # Active indices
+    active_indices = jnp.where(active_links_mask)[0]
+
+    def active_to_full(active_joints, initial_position):
+        full = initial_position.copy()
+        return full.at[active_indices].set(active_joints)
+
+    def active_from_full(joints):
+        return joints[active_links_mask]
+
+    # Target
+    target_position = target_frame_jax[:3, 3]
+
+    # Define residual function for least_squares
+    ORIENTATION_COEFF = 1.0
+
+    def compute_residuals(active_joints):
+        active_joints = jnp.array(active_joints)
+        full_joints = active_to_full(active_joints, starting_nodes_angles_jax)
+        fk = forward_kinematics_jax(full_joints, chain_params)
+
+        errors = []
+
+        if not no_position:
+            position_error = fk[:3, 3] - target_position
+            errors.append(position_error)
+
+        if orientation_mode == "X":
+            orientation_error = ORIENTATION_COEFF * (fk[:3, 0] - target_frame_jax[:3, 0])
+            errors.append(orientation_error)
+        elif orientation_mode == "Y":
+            orientation_error = ORIENTATION_COEFF * (fk[:3, 1] - target_frame_jax[:3, 1])
+            errors.append(orientation_error)
+        elif orientation_mode == "Z":
+            orientation_error = ORIENTATION_COEFF * (fk[:3, 2] - target_frame_jax[:3, 2])
+            errors.append(orientation_error)
+        elif orientation_mode == "all":
+            orientation_error = ORIENTATION_COEFF * (fk[:3, :3] - target_frame_jax[:3, :3]).ravel()
+            errors.append(orientation_error)
+
+        return jnp.concatenate(errors) if len(errors) > 1 else errors[0]
+
+    # Wrap for numpy compatibility
+    def residuals_np(x):
+        return np.array(compute_residuals(x))
+
+    # Add regularization if needed
+    if regularization_parameter is not None:
+        starting_active = active_from_full(starting_nodes_angles_jax)
+
+        def residuals_with_reg(x):
+            base_residuals = compute_residuals(jnp.array(x))
+            reg = regularization_parameter * jnp.linalg.norm(jnp.array(x) - starting_active)
+            return np.array(base_residuals + reg)
+
+        optimize_fn = residuals_with_reg
+    else:
+        optimize_fn = residuals_np
+
+    # Compute Jacobian using JAX
+    jac_fn = jax.jacfwd(compute_residuals)
+
+    def jacobian_np(x):
+        return np.array(jac_fn(jnp.array(x)))
+
+    # Initial point
+    x0 = np.array(active_from_full(starting_nodes_angles_jax))
+
+    if optimizer == "least_squares":
+        # Unzip bounds
+        bounds_unzipped = np.moveaxis(active_bounds, -1, 0)
+        result = scipy.optimize.least_squares(
+            optimize_fn, x0, jac=jacobian_np, bounds=bounds_unzipped
+        )
+    elif optimizer == "scalar":
+        def scalar_loss(x):
+            return np.linalg.norm(optimize_fn(x))
+        result = scipy.optimize.minimize(scalar_loss, x0, bounds=active_bounds)
+    else:
+        raise ValueError(f"Unknown optimizer: {optimizer}")
+
+    # Convert back to full joints
+    full_result = np.array(active_to_full(jnp.array(result.x), starting_nodes_angles_jax))
+    return full_result
+
+
+class JaxKinematicsCache:
+    """
+    Cache for JAX kinematics computations.
+    Stores JIT-compiled functions for a specific chain configuration.
+    """
+
+    def __init__(self, chain):
+        """
+        Initialize the cache for a chain.
+
+        Parameters
+        ----------
+        chain: ikpy.chain.Chain
+            The kinematic chain
+        """
+        self.chain = chain
+        self.chain_params = extract_chain_parameters(chain)
+        self.active_links_mask = jnp.array(chain.active_links_mask)
+        self.active_indices = jnp.where(self.active_links_mask)[0]
+
+        # JIT compile the forward kinematics
+        self._fk_jit = jit(partial(forward_kinematics_jax, chain_params=self.chain_params))
+        self._fk_full_jit = jit(partial(forward_kinematics_full_jax, chain_params=self.chain_params))
+
+        # Store bounds
+        bounds_list = [link.bounds for link in chain.links]
+        lower_bounds = []
+        upper_bounds = []
+        for mask, bounds in zip(chain.active_links_mask, bounds_list):
+            if mask:
+                lower_bounds.append(bounds[0] if np.isfinite(bounds[0]) else -np.pi * 2)
+                upper_bounds.append(bounds[1] if np.isfinite(bounds[1]) else np.pi * 2)
+        self.lower_bounds = jnp.array(lower_bounds)
+        self.upper_bounds = jnp.array(upper_bounds)
+
+    def forward_kinematics(self, joints, full_kinematics=False):
+        """
+        Compute forward kinematics.
+
+        Parameters
+        ----------
+        joints: array-like
+            Joint parameters
+        full_kinematics: bool
+            If True, return all intermediate frames
+
+        Returns
+        -------
+        np.ndarray
+            Transformation matrix or list of matrices
+        """
+        joints = jnp.array(joints)
+
+        if full_kinematics:
+            result = self._fk_full_jit(joints)
+            return [np.array(result[i]) for i in range(self.chain_params['n_links'])]
+        else:
+            return np.array(self._fk_jit(joints))
+
+    def active_to_full(self, active_joints, initial_position):
+        """Convert active joints to full joint array"""
+        initial_position = jnp.array(initial_position)
+        return initial_position.at[self.active_indices].set(active_joints)
+
+    def active_from_full(self, joints):
+        """Extract active joints from full joint array"""
+        return jnp.array(joints)[self.active_links_mask]
+
+    def inverse_kinematics(self, target_frame, initial_position=None,
+                           orientation_mode=None, no_position=False,
+                           regularization_parameter=None, max_iter=100,
+                           optimizer="L-BFGS-B", learning_rate=0.01, tol=1e-6):
+        """
+        Compute inverse kinematics using JAX optimization.
+
+        Parameters
+        ----------
+        target_frame: np.ndarray (4, 4)
+            Target pose
+        initial_position: np.ndarray
+            Initial joint positions
+        orientation_mode: str
+            Orientation constraint mode
+        no_position: bool
+            Disable position optimization
+        regularization_parameter: float
+            Regularization strength
+        max_iter: int
+            Maximum iterations
+        optimizer: str
+            Optimizer type
+        learning_rate: float
+            Learning rate for gradient-based optimizers
+        tol: float
+            Convergence tolerance
+
+        Returns
+        -------
+        np.ndarray
+            Optimal joint positions
+        """
+        if initial_position is None:
+            initial_position = np.zeros(len(self.chain.links))
+
+        return inverse_kinematics_jax(
+            self.chain, target_frame, initial_position,
+            regularization_parameter=regularization_parameter,
+            max_iter=max_iter,
+            orientation_mode=orientation_mode,
+            no_position=no_position,
+            optimizer=optimizer,
+            learning_rate=learning_rate,
+            tol=tol
+        )

--- a/src/ikpy/utils/jax_geometry.py
+++ b/src/ikpy/utils/jax_geometry.py
@@ -1,0 +1,242 @@
+# coding= utf8
+"""
+.. module:: jax_geometry
+This module contains JAX-based helper functions for 3D geometric transformations.
+These are JIT-compilable and differentiable versions of the numpy geometry functions.
+"""
+import jax.numpy as jnp
+from jax import jit
+
+
+@jit
+def rx_matrix(theta):
+    """Rotation matrix around the X axis"""
+    c = jnp.cos(theta)
+    s = jnp.sin(theta)
+    return jnp.array([
+        [1.0, 0.0, 0.0],
+        [0.0, c, -s],
+        [0.0, s, c]
+    ])
+
+
+@jit
+def ry_matrix(theta):
+    """Rotation matrix around the Y axis"""
+    c = jnp.cos(theta)
+    s = jnp.sin(theta)
+    return jnp.array([
+        [c, 0.0, s],
+        [0.0, 1.0, 0.0],
+        [-s, 0.0, c]
+    ])
+
+
+@jit
+def rz_matrix(theta):
+    """Rotation matrix around the Z axis"""
+    c = jnp.cos(theta)
+    s = jnp.sin(theta)
+    return jnp.array([
+        [c, -s, 0.0],
+        [s, c, 0.0],
+        [0.0, 0.0, 1.0]
+    ])
+
+
+@jit
+def rotation_matrix(phi, theta, psi):
+    """Return a rotation matrix using the given Euler angles"""
+    return jnp.dot(rz_matrix(phi), jnp.dot(rx_matrix(theta), rz_matrix(psi)))
+
+
+@jit
+def rpy_matrix(roll, pitch, yaw):
+    """Return a rotation matrix described by the extrinsic roll, pitch, yaw coordinates"""
+    return jnp.dot(rz_matrix(yaw), jnp.dot(ry_matrix(pitch), rx_matrix(roll)))
+
+
+@jit
+def axis_rotation_matrix(axis, theta):
+    """Returns a rotation matrix around the given axis using Rodrigues' rotation formula"""
+    x, y, z = axis[0], axis[1], axis[2]
+    c = jnp.cos(theta)
+    s = jnp.sin(theta)
+
+    return jnp.array([
+        [x ** 2 + (1 - x ** 2) * c, x * y * (1 - c) - z * s, x * z * (1 - c) + y * s],
+        [x * y * (1 - c) + z * s, y ** 2 + (1 - y ** 2) * c, y * z * (1 - c) - x * s],
+        [x * z * (1 - c) - y * s, y * z * (1 - c) + x * s, z ** 2 + (1 - z ** 2) * c]
+    ])
+
+
+@jit
+def homogeneous_translation_matrix(trans_x, trans_y, trans_z):
+    """Return a translation matrix in homogeneous space"""
+    return jnp.array([
+        [1.0, 0.0, 0.0, trans_x],
+        [0.0, 1.0, 0.0, trans_y],
+        [0.0, 0.0, 1.0, trans_z],
+        [0.0, 0.0, 0.0, 1.0]
+    ])
+
+
+@jit
+def get_translation_matrix(mu):
+    """Returns a translation matrix of the given mu"""
+    translation_matrix = jnp.eye(4)
+    translation_matrix = translation_matrix.at[:3, 3].set(mu)
+    return translation_matrix
+
+
+@jit
+def cartesian_to_homogeneous(cartesian_matrix):
+    """Converts a 3x3 cartesian matrix to a 4x4 homogeneous matrix"""
+    homogeneous_matrix = jnp.eye(4)
+    homogeneous_matrix = homogeneous_matrix.at[:3, :3].set(cartesian_matrix)
+    return homogeneous_matrix
+
+
+@jit
+def cartesian_to_homogeneous_vectors(cartesian_vector):
+    """Converts a 3D cartesian vector to a 4D homogeneous vector"""
+    return jnp.array([cartesian_vector[0], cartesian_vector[1], cartesian_vector[2], 1.0])
+
+
+@jit
+def homogeneous_to_cartesian_vectors(homogeneous_vector):
+    """Convert a homogeneous vector to cartesian vector"""
+    return homogeneous_vector[:3]
+
+
+@jit
+def homogeneous_to_cartesian(homogeneous_matrix):
+    """Convert a homogeneous matrix to cartesian matrix"""
+    return homogeneous_matrix[:3, :3]
+
+
+@jit
+def from_transformation_matrix(transformation_matrix):
+    """Convert a transformation matrix to a tuple (translation_vector, rotation_matrix)"""
+    return transformation_matrix[:, -1], transformation_matrix[:3, :3]
+
+
+@jit
+def to_transformation_matrix(translation, orientation_matrix):
+    """Convert a tuple (translation_vector, orientation_matrix) to a transformation matrix"""
+    matrix = jnp.eye(4)
+    matrix = matrix.at[:3, :3].set(orientation_matrix)
+    matrix = matrix.at[:3, 3].set(translation)
+    return matrix
+
+
+def compute_link_frame_matrix_revolute(origin_translation, origin_orientation, rotation_axis, theta):
+    """
+    Compute the link frame matrix for a revolute joint.
+
+    Parameters
+    ----------
+    origin_translation: jnp.ndarray
+        The translation vector (3,)
+    origin_orientation: jnp.ndarray
+        The orientation as roll, pitch, yaw (3,)
+    rotation_axis: jnp.ndarray
+        The rotation axis (3,)
+    theta: float
+        The joint angle
+
+    Returns
+    -------
+    jnp.ndarray
+        4x4 transformation matrix
+    """
+    # Translation matrix
+    frame_matrix = homogeneous_translation_matrix(
+        origin_translation[0],
+        origin_translation[1],
+        origin_translation[2]
+    )
+
+    # Orientation matrix
+    orientation = cartesian_to_homogeneous(
+        rpy_matrix(origin_orientation[0], origin_orientation[1], origin_orientation[2])
+    )
+    frame_matrix = jnp.dot(frame_matrix, orientation)
+
+    # Rotation matrix
+    rotation = cartesian_to_homogeneous(axis_rotation_matrix(rotation_axis, theta))
+    frame_matrix = jnp.dot(frame_matrix, rotation)
+
+    return frame_matrix
+
+
+def compute_link_frame_matrix_prismatic(origin_translation, origin_orientation, translation_axis, mu):
+    """
+    Compute the link frame matrix for a prismatic joint.
+
+    Parameters
+    ----------
+    origin_translation: jnp.ndarray
+        The translation vector (3,)
+    origin_orientation: jnp.ndarray
+        The orientation as roll, pitch, yaw (3,)
+    translation_axis: jnp.ndarray
+        The translation axis (3,)
+    mu: float
+        The joint translation
+
+    Returns
+    -------
+    jnp.ndarray
+        4x4 transformation matrix
+    """
+    # Translation matrix
+    frame_matrix = homogeneous_translation_matrix(
+        origin_translation[0],
+        origin_translation[1],
+        origin_translation[2]
+    )
+
+    # Orientation matrix
+    orientation = cartesian_to_homogeneous(
+        rpy_matrix(origin_orientation[0], origin_orientation[1], origin_orientation[2])
+    )
+    frame_matrix = jnp.dot(frame_matrix, orientation)
+
+    # Translation
+    translation_vector = translation_axis * mu
+    frame_matrix = jnp.dot(frame_matrix, get_translation_matrix(translation_vector))
+
+    return frame_matrix
+
+
+def compute_link_frame_matrix_fixed(origin_translation, origin_orientation):
+    """
+    Compute the link frame matrix for a fixed joint.
+
+    Parameters
+    ----------
+    origin_translation: jnp.ndarray
+        The translation vector (3,)
+    origin_orientation: jnp.ndarray
+        The orientation as roll, pitch, yaw (3,)
+
+    Returns
+    -------
+    jnp.ndarray
+        4x4 transformation matrix
+    """
+    # Translation matrix
+    frame_matrix = homogeneous_translation_matrix(
+        origin_translation[0],
+        origin_translation[1],
+        origin_translation[2]
+    )
+
+    # Orientation matrix
+    orientation = cartesian_to_homogeneous(
+        rpy_matrix(origin_orientation[0], origin_orientation[1], origin_orientation[2])
+    )
+    frame_matrix = jnp.dot(frame_matrix, orientation)
+
+    return frame_matrix

--- a/tests/profile_jax_overhead.py
+++ b/tests/profile_jax_overhead.py
@@ -1,0 +1,1239 @@
+"""
+Profiling script to measure JAX overhead vs NumPy for single-point IK.
+"""
+
+import numpy as np
+import time
+import os
+import json
+
+# Enable JAX float64 mode for better precision
+os.environ['JAX_ENABLE_X64'] = 'True'
+
+from ikpy import chain
+from ikpy import JAX_AVAILABLE
+
+# Debug logging helper
+LOG_PATH = "/Users/pim/000_COURS/ikpy/.cursor/debug.log"
+
+# Ensure log directory exists
+os.makedirs(os.path.dirname(LOG_PATH), exist_ok=True)
+
+def log_timing(location, message, data):
+    """Append timing data to debug log in NDJSON format"""
+    import json
+    entry = {
+        "timestamp": time.time() * 1000,
+        "location": location,
+        "message": message,
+        "data": data,
+        "sessionId": "profile-jax-overhead",
+        "hypothesisId": data.get("hypothesis", "general")
+    }
+    with open(LOG_PATH, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+
+def profile_single_ik():
+    """Profile a single IK call for both NumPy and JAX backends"""
+    
+    # #region agent log
+    log_timing("profile_single_ik:start", "Starting profiling", {"hypothesis": "general"})
+    # #endregion
+    
+    # Load Baxter chain (more complex, realistic use case)
+    json_path = os.path.join(os.path.dirname(__file__), "../resources/baxter/baxter_left_arm.json")
+    urdf_path = os.path.join(os.path.dirname(__file__), "../resources/baxter/baxter.urdf")
+    
+    with open(json_path) as f:
+        config = json.load(f)
+    
+    baxter_chain = chain.Chain.from_urdf_file(
+        urdf_path,
+        base_elements=config["elements"],
+        active_links_mask=config["active_links_mask"],
+        last_link_vector=config["last_link_vector"],
+        name=config["name"]
+    )
+    
+    print(f"\n{'='*70}")
+    print(f"Profiling Single-Point IK: Baxter ({len(baxter_chain.links)} links, 7 active)")
+    print(f"{'='*70}")
+    
+    # Target position
+    target = [0.6, 0.3, 0.2]
+    initial_position = [0.0] * len(baxter_chain.links)
+    
+    # ============================================
+    # Warm-up: Force JAX compilation (AOT)
+    # ============================================
+    # #region agent log
+    t_warmup_start = time.perf_counter()
+    # #endregion
+    
+    _ = baxter_chain.jax_cache  # Force cache creation and AOT compilation
+    _ = baxter_chain.inverse_kinematics(target_position=target, backend="jax", optimizer="scipy")
+    
+    # #region agent log
+    t_warmup_end = time.perf_counter()
+    log_timing("warmup", "JAX warmup complete", {
+        "duration_ms": (t_warmup_end - t_warmup_start) * 1000,
+        "hypothesis": "general"
+    })
+    # #endregion
+    
+    print(f"\nJAX warmup (compilation): {(t_warmup_end - t_warmup_start)*1000:.2f} ms")
+    
+    # ============================================
+    # SINGLE CALL PROFILING
+    # ============================================
+    n_calls = 1
+    
+    print(f"\n--- Single Call Timing (n={n_calls}) ---")
+    
+    # NumPy single call
+    # #region agent log
+    t_numpy_start = time.perf_counter()
+    # #endregion
+    
+    result_numpy = baxter_chain.inverse_kinematics(
+        target_position=target,
+        initial_position=initial_position,
+        backend="numpy"
+    )
+    
+    # #region agent log
+    t_numpy_end = time.perf_counter()
+    numpy_single_ms = (t_numpy_end - t_numpy_start) * 1000
+    log_timing("single_ik:numpy", "NumPy single IK call", {
+        "duration_ms": numpy_single_ms,
+        "hypothesis": "H4"
+    })
+    # #endregion
+    
+    # JAX single call
+    # #region agent log
+    t_jax_start = time.perf_counter()
+    # #endregion
+    
+    result_jax = baxter_chain.inverse_kinematics(
+        target_position=target,
+        initial_position=initial_position,
+        backend="jax",
+        optimizer="scipy"
+    )
+    
+    # #region agent log
+    t_jax_end = time.perf_counter()
+    jax_single_ms = (t_jax_end - t_jax_start) * 1000
+    log_timing("single_ik:jax", "JAX single IK call", {
+        "duration_ms": jax_single_ms,
+        "hypothesis": "H4"
+    })
+    # #endregion
+    
+    print(f"NumPy: {numpy_single_ms:.3f} ms")
+    print(f"JAX:   {jax_single_ms:.3f} ms")
+    print(f"Ratio: JAX is {jax_single_ms/numpy_single_ms:.2f}x {'slower' if jax_single_ms > numpy_single_ms else 'faster'}")
+    
+    # ============================================
+    # DETAILED BREAKDOWN: JAX internals
+    # ============================================
+    print(f"\n--- Detailed JAX Breakdown ---")
+    
+    import jax.numpy as jnp
+    cache = baxter_chain.jax_cache
+    
+    # H1: Test conversion overhead
+    # #region agent log
+    t_conv_start = time.perf_counter()
+    # #endregion
+    
+    for _ in range(100):
+        target_frame_jax = jnp.array(np.eye(4), dtype=cache._dtype)
+        initial_position_jax = jnp.array(initial_position, dtype=cache._dtype)
+    
+    # #region agent log
+    t_conv_end = time.perf_counter()
+    conv_time_per_call = (t_conv_end - t_conv_start) / 100 * 1000
+    log_timing("conversion:numpy_to_jax", "NumPy to JAX conversion (100x avg)", {
+        "duration_ms_per_call": conv_time_per_call,
+        "hypothesis": "H1"
+    })
+    # #endregion
+    
+    print(f"H1 - NumPy→JAX conversion: {conv_time_per_call:.4f} ms/call")
+    
+    # H1b: Test reverse conversion overhead
+    # #region agent log
+    t_rconv_start = time.perf_counter()
+    # #endregion
+    
+    jax_result = jnp.zeros(len(baxter_chain.links), dtype=cache._dtype)
+    for _ in range(100):
+        _ = np.array(jax_result)
+    
+    # #region agent log
+    t_rconv_end = time.perf_counter()
+    rconv_time_per_call = (t_rconv_end - t_rconv_start) / 100 * 1000
+    log_timing("conversion:jax_to_numpy", "JAX to NumPy conversion (100x avg)", {
+        "duration_ms_per_call": rconv_time_per_call,
+        "hypothesis": "H1"
+    })
+    # #endregion
+    
+    print(f"H1 - JAX→NumPy conversion: {rconv_time_per_call:.4f} ms/call")
+    
+    # H2: Test compiled function dispatch overhead
+    target_frame_jax = jnp.array(np.eye(4), dtype=cache._dtype)
+    target_frame_jax = target_frame_jax.at[:3, 3].set(jnp.array(target, dtype=cache._dtype))
+    initial_position_jax = jnp.array(initial_position, dtype=cache._dtype)
+    
+    # #region agent log
+    t_dispatch_start = time.perf_counter()
+    # #endregion
+    
+    residual_fn = cache._ik_residuals[(None, False)]
+    x0 = cache.active_from_full(initial_position_jax)
+    for _ in range(100):
+        _ = residual_fn(x0, target_frame_jax, initial_position_jax)
+    
+    # #region agent log
+    t_dispatch_end = time.perf_counter()
+    dispatch_time_per_call = (t_dispatch_end - t_dispatch_start) / 100 * 1000
+    log_timing("dispatch:residual_fn", "Compiled residual fn dispatch (100x avg)", {
+        "duration_ms_per_call": dispatch_time_per_call,
+        "hypothesis": "H2"
+    })
+    # #endregion
+    
+    print(f"H2 - Compiled residual dispatch: {dispatch_time_per_call:.4f} ms/call")
+    
+    # H2b: Test jacobian compiled function dispatch
+    # #region agent log
+    t_jac_start = time.perf_counter()
+    # #endregion
+    
+    jacobian_fn = cache._ik_jacobian[(None, False)]
+    for _ in range(100):
+        _ = jacobian_fn(x0, target_frame_jax, initial_position_jax)
+    
+    # #region agent log
+    t_jac_end = time.perf_counter()
+    jac_time_per_call = (t_jac_end - t_jac_start) / 100 * 1000
+    log_timing("dispatch:jacobian_fn", "Compiled jacobian fn dispatch (100x avg)", {
+        "duration_ms_per_call": jac_time_per_call,
+        "hypothesis": "H2"
+    })
+    # #endregion
+    
+    print(f"H2 - Compiled jacobian dispatch: {jac_time_per_call:.4f} ms/call")
+    
+    # H3: Test array mutation overhead
+    # #region agent log
+    t_mut_start = time.perf_counter()
+    # #endregion
+    
+    for _ in range(100):
+        _ = initial_position_jax.at[cache.active_indices].set(x0)
+    
+    # #region agent log
+    t_mut_end = time.perf_counter()
+    mut_time_per_call = (t_mut_end - t_mut_start) / 100 * 1000
+    log_timing("mutation:at_set", "Array .at[].set() mutation (100x avg)", {
+        "duration_ms_per_call": mut_time_per_call,
+        "hypothesis": "H3"
+    })
+    # #endregion
+    
+    print(f"H3 - Array mutation (.at[].set()): {mut_time_per_call:.4f} ms/call")
+    
+    # H5: Compare Jacobian computation
+    print(f"\n--- Jacobian Computation Comparison ---")
+    
+    # NumPy: Uses finite differences in scipy
+    # JAX: Uses analytical autodiff
+    
+    # Measure scipy least_squares without JAX
+    import scipy.optimize
+    
+    def numpy_residuals(x):
+        full_joints = baxter_chain.active_to_full(x, initial_position)
+        fk = baxter_chain.forward_kinematics(full_joints, backend="numpy")
+        return fk[:3, 3] - target
+    
+    x0_np = baxter_chain.active_from_full(initial_position)
+    bounds_np = np.array([link.bounds for link in baxter_chain.links])
+    bounds_np = baxter_chain.active_from_full(bounds_np)
+    bounds_np = np.moveaxis(bounds_np, -1, 0)
+    
+    # #region agent log
+    t_scipy_np_start = time.perf_counter()
+    # #endregion
+    
+    result_scipy_np = scipy.optimize.least_squares(
+        numpy_residuals,
+        x0_np,
+        bounds=bounds_np
+    )
+    
+    # #region agent log
+    t_scipy_np_end = time.perf_counter()
+    scipy_np_ms = (t_scipy_np_end - t_scipy_np_start) * 1000
+    log_timing("scipy:numpy_finite_diff", "SciPy with finite diff Jacobian", {
+        "duration_ms": scipy_np_ms,
+        "n_function_evals": result_scipy_np.nfev,
+        "n_jacobian_evals": result_scipy_np.njev,
+        "hypothesis": "H5"
+    })
+    # #endregion
+    
+    print(f"NumPy+SciPy (finite diff): {scipy_np_ms:.3f} ms")
+    print(f"  Function evaluations: {result_scipy_np.nfev}, Jacobian evaluations: {result_scipy_np.njev}")
+    
+    # Scipy with JAX analytical Jacobian
+    def jax_residuals(x):
+        return np.array(residual_fn(
+            jnp.array(x, dtype=cache._dtype),
+            target_frame_jax,
+            initial_position_jax
+        ))
+    
+    def jax_jacobian(x):
+        return np.array(jacobian_fn(
+            jnp.array(x, dtype=cache._dtype),
+            target_frame_jax,
+            initial_position_jax
+        ))
+    
+    # #region agent log
+    t_scipy_jax_start = time.perf_counter()
+    # #endregion
+    
+    result_scipy_jax = scipy.optimize.least_squares(
+        jax_residuals,
+        np.array(x0),
+        jac=jax_jacobian,
+        bounds=(np.array(cache.lower_bounds), np.array(cache.upper_bounds))
+    )
+    
+    # #region agent log
+    t_scipy_jax_end = time.perf_counter()
+    scipy_jax_ms = (t_scipy_jax_end - t_scipy_jax_start) * 1000
+    log_timing("scipy:jax_analytical_jac", "SciPy with JAX analytical Jacobian", {
+        "duration_ms": scipy_jax_ms,
+        "n_function_evals": result_scipy_jax.nfev,
+        "n_jacobian_evals": result_scipy_jax.njev,
+        "hypothesis": "H5"
+    })
+    # #endregion
+    
+    print(f"JAX+SciPy (analytical jac): {scipy_jax_ms:.3f} ms")
+    print(f"  Function evaluations: {result_scipy_jax.nfev}, Jacobian evaluations: {result_scipy_jax.njev}")
+    
+    # ============================================
+    # MULTIPLE CALLS PROFILING (amortized cost)
+    # ============================================
+    n_iterations = 100
+    
+    print(f"\n--- Multiple Calls ({n_iterations}x) Amortized Timing ---")
+    
+    # NumPy multiple calls
+    # #region agent log
+    t_numpy_multi_start = time.perf_counter()
+    # #endregion
+    
+    for _ in range(n_iterations):
+        _ = baxter_chain.inverse_kinematics(
+            target_position=target,
+            initial_position=initial_position,
+            backend="numpy"
+        )
+    
+    # #region agent log
+    t_numpy_multi_end = time.perf_counter()
+    numpy_multi_ms = (t_numpy_multi_end - t_numpy_multi_start) * 1000
+    log_timing("multi_ik:numpy", f"NumPy {n_iterations}x IK calls", {
+        "total_duration_ms": numpy_multi_ms,
+        "per_call_ms": numpy_multi_ms / n_iterations,
+        "hypothesis": "H4"
+    })
+    # #endregion
+    
+    # JAX multiple calls
+    # #region agent log
+    t_jax_multi_start = time.perf_counter()
+    # #endregion
+    
+    for _ in range(n_iterations):
+        _ = baxter_chain.inverse_kinematics(
+            target_position=target,
+            initial_position=initial_position,
+            backend="jax",
+            optimizer="scipy"
+        )
+    
+    # #region agent log
+    t_jax_multi_end = time.perf_counter()
+    jax_multi_ms = (t_jax_multi_end - t_jax_multi_start) * 1000
+    log_timing("multi_ik:jax", f"JAX {n_iterations}x IK calls", {
+        "total_duration_ms": jax_multi_ms,
+        "per_call_ms": jax_multi_ms / n_iterations,
+        "hypothesis": "H4"
+    })
+    # #endregion
+    
+    print(f"NumPy: {numpy_multi_ms:.2f} ms total, {numpy_multi_ms/n_iterations:.3f} ms/call")
+    print(f"JAX:   {jax_multi_ms:.2f} ms total, {jax_multi_ms/n_iterations:.3f} ms/call")
+    print(f"Ratio: JAX is {jax_multi_ms/numpy_multi_ms:.2f}x {'slower' if jax_multi_ms > numpy_multi_ms else 'faster'}")
+    
+    # ============================================
+    # SUMMARY
+    # ============================================
+    print(f"\n{'='*70}")
+    print("OVERHEAD SUMMARY")
+    print(f"{'='*70}")
+    
+    total_jax_overhead = conv_time_per_call + rconv_time_per_call + dispatch_time_per_call + mut_time_per_call
+    print(f"\nEstimated JAX overhead per IK call:")
+    print(f"  - NumPy→JAX conversion: {conv_time_per_call:.4f} ms")
+    print(f"  - JAX→NumPy conversion: {rconv_time_per_call:.4f} ms")
+    print(f"  - Compiled fn dispatch:  {dispatch_time_per_call:.4f} ms")
+    print(f"  - Array mutations:       {mut_time_per_call:.4f} ms")
+    print(f"  ---------------------------------")
+    print(f"  Total measured overhead: ~{total_jax_overhead:.4f} ms")
+    print(f"\n  But single call delta:   {jax_single_ms - numpy_single_ms:.3f} ms")
+    
+    # #region agent log
+    log_timing("summary", "Profiling summary", {
+        "numpy_single_ms": numpy_single_ms,
+        "jax_single_ms": jax_single_ms,
+        "conversion_overhead_ms": conv_time_per_call + rconv_time_per_call,
+        "dispatch_overhead_ms": dispatch_time_per_call,
+        "mutation_overhead_ms": mut_time_per_call,
+        "estimated_total_overhead_ms": total_jax_overhead,
+        "actual_delta_ms": jax_single_ms - numpy_single_ms,
+        "hypothesis": "summary"
+    })
+    # #endregion
+    
+    # Verify results are similar
+    fk_numpy = baxter_chain.forward_kinematics(result_numpy)[:3, 3]
+    fk_jax = baxter_chain.forward_kinematics(result_jax)[:3, 3]
+    
+    print(f"\nResult verification:")
+    print(f"  NumPy error to target: {np.linalg.norm(fk_numpy - target)*1000:.4f} mm")
+    print(f"  JAX error to target:   {np.linalg.norm(fk_jax - target)*1000:.4f} mm")
+
+
+def profile_simple_chain():
+    """Profile with a simpler chain to see if overhead becomes more visible"""
+    
+    # #region agent log
+    log_timing("profile_simple:start", "Starting simple chain profiling", {"hypothesis": "general"})
+    # #endregion
+    
+    # Load simpler Poppy Torso chain (4 active joints)
+    urdf_path = os.path.join(os.path.dirname(__file__), "../resources/poppy_torso/poppy_torso.URDF")
+    simple_chain = chain.Chain.from_urdf_file(
+        urdf_path,
+        base_elements=[
+            "base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x",
+            "chest", "r_shoulder_y"
+        ],
+        last_link_vector=[0, 0.18, 0],
+        active_links_mask=[
+            False, False, False, False, True, True, True, True, False
+        ]
+    )
+    
+    print(f"\n{'='*70}")
+    print(f"Profiling Simple Chain: Poppy Torso ({len(simple_chain.links)} links, 4 active)")
+    print(f"{'='*70}")
+    
+    target = [0.1, -0.2, 0.1]
+    initial_position = [0.0] * len(simple_chain.links)
+    
+    # Warmup JAX
+    t_warmup_start = time.perf_counter()
+    _ = simple_chain.jax_cache
+    _ = simple_chain.inverse_kinematics(target_position=target, backend="jax", optimizer="scipy")
+    t_warmup_end = time.perf_counter()
+    
+    # #region agent log
+    log_timing("simple:warmup", "Simple chain JAX warmup", {
+        "duration_ms": (t_warmup_end - t_warmup_start) * 1000,
+        "hypothesis": "general"
+    })
+    # #endregion
+    
+    print(f"\nJAX warmup: {(t_warmup_end - t_warmup_start)*1000:.2f} ms")
+    
+    # Single call comparison
+    n_iterations = 100
+    
+    # NumPy
+    t_np_start = time.perf_counter()
+    for _ in range(n_iterations):
+        _ = simple_chain.inverse_kinematics(target_position=target, initial_position=initial_position, backend="numpy")
+    t_np_end = time.perf_counter()
+    numpy_ms = (t_np_end - t_np_start) / n_iterations * 1000
+    
+    # JAX
+    t_jax_start = time.perf_counter()
+    for _ in range(n_iterations):
+        _ = simple_chain.inverse_kinematics(target_position=target, initial_position=initial_position, backend="jax", optimizer="scipy")
+    t_jax_end = time.perf_counter()
+    jax_ms = (t_jax_end - t_jax_start) / n_iterations * 1000
+    
+    # #region agent log
+    log_timing("simple:comparison", "Simple chain comparison", {
+        "numpy_ms_per_call": numpy_ms,
+        "jax_ms_per_call": jax_ms,
+        "ratio": jax_ms / numpy_ms,
+        "hypothesis": "H4"
+    })
+    # #endregion
+    
+    print(f"\n--- Per-call timing ({n_iterations}x average) ---")
+    print(f"NumPy: {numpy_ms:.3f} ms/call")
+    print(f"JAX:   {jax_ms:.3f} ms/call")
+    print(f"Ratio: JAX is {jax_ms/numpy_ms:.2f}x {'slower' if jax_ms > numpy_ms else 'faster'}")
+    
+    # Detailed analysis with function evaluations
+    import scipy.optimize
+    import jax.numpy as jnp
+    
+    cache = simple_chain.jax_cache
+    target_frame = np.eye(4)
+    target_frame[:3, 3] = target
+    target_frame_jax = jnp.array(target_frame, dtype=cache._dtype)
+    initial_position_jax = jnp.array(initial_position, dtype=cache._dtype)
+    
+    # NumPy scipy details
+    def numpy_residuals(x):
+        full_joints = simple_chain.active_to_full(x, initial_position)
+        fk = simple_chain.forward_kinematics(full_joints, backend="numpy")
+        return fk[:3, 3] - target
+    
+    x0_np = simple_chain.active_from_full(initial_position)
+    bounds_np = np.array([link.bounds for link in simple_chain.links])
+    bounds_np = simple_chain.active_from_full(bounds_np)
+    bounds_np = np.moveaxis(bounds_np, -1, 0)
+    
+    t_np_start = time.perf_counter()
+    result_np = scipy.optimize.least_squares(numpy_residuals, x0_np, bounds=bounds_np)
+    t_np_end = time.perf_counter()
+    
+    # JAX scipy details
+    residual_fn = cache._ik_residuals[(None, False)]
+    jacobian_fn = cache._ik_jacobian[(None, False)]
+    
+    def jax_residuals(x):
+        return np.array(residual_fn(
+            jnp.array(x, dtype=cache._dtype),
+            target_frame_jax,
+            initial_position_jax
+        ))
+    
+    def jax_jacobian(x):
+        return np.array(jacobian_fn(
+            jnp.array(x, dtype=cache._dtype),
+            target_frame_jax,
+            initial_position_jax
+        ))
+    
+    x0_jax = np.array(cache.active_from_full(initial_position_jax))
+    
+    t_jax_start = time.perf_counter()
+    result_jax = scipy.optimize.least_squares(
+        jax_residuals, x0_jax, jac=jax_jacobian,
+        bounds=(np.array(cache.lower_bounds), np.array(cache.upper_bounds))
+    )
+    t_jax_end = time.perf_counter()
+    
+    # #region agent log
+    log_timing("simple:scipy_detail", "Simple chain scipy details", {
+        "numpy_time_ms": (t_np_end - t_np_start) * 1000,
+        "numpy_nfev": result_np.nfev,
+        "numpy_njev": result_np.njev,
+        "jax_time_ms": (t_jax_end - t_jax_start) * 1000,
+        "jax_nfev": result_jax.nfev,
+        "jax_njev": result_jax.njev,
+        "hypothesis": "H5"
+    })
+    # #endregion
+    
+    print(f"\n--- Single-call scipy details ---")
+    print(f"NumPy: {(t_np_end - t_np_start)*1000:.3f} ms, nfev={result_np.nfev}, njev={result_np.njev}")
+    print(f"JAX:   {(t_jax_end - t_jax_start)*1000:.3f} ms, nfev={result_jax.nfev}, njev={result_jax.njev}")
+    
+    # Check position error
+    fk_np = simple_chain.forward_kinematics(simple_chain.active_to_full(result_np.x, initial_position))[:3, 3]
+    fk_jax = simple_chain.forward_kinematics(simple_chain.active_to_full(result_jax.x, initial_position))[:3, 3]
+    print(f"\nPosition errors:")
+    print(f"NumPy: {np.linalg.norm(fk_np - target)*1000:.4f} mm")
+    print(f"JAX:   {np.linalg.norm(fk_jax - target)*1000:.4f} mm")
+    
+    # H6: Check if bounds are the same
+    print(f"\n--- H6: Bounds comparison ---")
+    print(f"NumPy bounds shape: {bounds_np.shape}")
+    print(f"NumPy bounds: {bounds_np}")
+    print(f"JAX lower_bounds: {np.array(cache.lower_bounds)}")
+    print(f"JAX upper_bounds: {np.array(cache.upper_bounds)}")
+    
+    # H6: Check dtype
+    print(f"\nJAX dtype: {cache._dtype}")
+    print(f"JAX float64 enabled: {cache._use_float64}")
+    
+    # #region agent log
+    log_timing("simple:bounds_check", "Bounds comparison", {
+        "numpy_lower": bounds_np[0].tolist(),
+        "numpy_upper": bounds_np[1].tolist(),
+        "jax_lower": np.array(cache.lower_bounds).tolist(),
+        "jax_upper": np.array(cache.upper_bounds).tolist(),
+        "jax_dtype": str(cache._dtype),
+        "jax_float64": cache._use_float64,
+        "hypothesis": "H6"
+    })
+    # #endregion
+    
+    # H6b: Test with same bounds - use numpy bounds for JAX
+    print(f"\n--- H6b: JAX with NumPy-style bounds ---")
+    t_jax2_start = time.perf_counter()
+    result_jax2 = scipy.optimize.least_squares(
+        jax_residuals, x0_jax, jac=jax_jacobian,
+        bounds=bounds_np  # Use same bounds as numpy
+    )
+    t_jax2_end = time.perf_counter()
+    print(f"JAX (numpy bounds): {(t_jax2_end - t_jax2_start)*1000:.3f} ms, nfev={result_jax2.nfev}, njev={result_jax2.njev}")
+    
+    # #region agent log
+    log_timing("simple:jax_numpy_bounds", "JAX with NumPy bounds", {
+        "time_ms": (t_jax2_end - t_jax2_start) * 1000,
+        "nfev": result_jax2.nfev,
+        "njev": result_jax2.njev,
+        "hypothesis": "H6"
+    })
+    # #endregion
+    
+    # H7: Compare Jacobians at initial point
+    print(f"\n--- H7: Jacobian comparison at x0 ---")
+    
+    # NumPy finite diff jacobian (approximate)
+    eps = 1e-8
+    n_active = len(x0_np)
+    jac_fd = np.zeros((3, n_active))
+    f0 = numpy_residuals(x0_np)
+    for i in range(n_active):
+        x_plus = x0_np.copy()
+        x_plus[i] += eps
+        f_plus = numpy_residuals(x_plus)
+        jac_fd[:, i] = (f_plus - f0) / eps
+    
+    # JAX analytical jacobian
+    jac_jax = jax_jacobian(x0_jax)
+    
+    print(f"Finite diff Jacobian:\n{jac_fd}")
+    print(f"\nJAX Jacobian:\n{jac_jax}")
+    print(f"\nDifference (JAX - FD):\n{jac_jax - jac_fd}")
+    print(f"Max abs difference: {np.max(np.abs(jac_jax - jac_fd))}")
+    print(f"Relative difference: {np.linalg.norm(jac_jax - jac_fd) / np.linalg.norm(jac_fd) * 100:.4f}%")
+    
+    # #region agent log
+    log_timing("simple:jacobian_comparison", "Jacobian comparison", {
+        "fd_jacobian": jac_fd.tolist(),
+        "jax_jacobian": jac_jax.tolist(),
+        "max_abs_diff": float(np.max(np.abs(jac_jax - jac_fd))),
+        "relative_diff_pct": float(np.linalg.norm(jac_jax - jac_fd) / np.linalg.norm(jac_fd) * 100),
+        "hypothesis": "H7"
+    })
+    # #endregion
+    
+    # H7b: Try scipy with no jacobian hint (let it estimate)
+    print(f"\n--- H7b: JAX residuals + scipy auto-jacobian ---")
+    t_auto_start = time.perf_counter()
+    result_auto = scipy.optimize.least_squares(
+        jax_residuals, x0_jax, bounds=bounds_np
+    )
+    t_auto_end = time.perf_counter()
+    print(f"JAX residuals + auto-jac: {(t_auto_end - t_auto_start)*1000:.3f} ms, nfev={result_auto.nfev}, njev={result_auto.njev}")
+    
+    # #region agent log
+    log_timing("simple:jax_auto_jac", "JAX residuals with auto jacobian", {
+        "time_ms": (t_auto_end - t_auto_start) * 1000,
+        "nfev": result_auto.nfev,
+        "njev": result_auto.njev,
+        "hypothesis": "H7"
+    })
+    # #endregion
+    
+    # H8: Check Jacobian format and order
+    print(f"\n--- H8: Jacobian format analysis ---")
+    
+    # Check what scipy's finite diff produces
+    def fd_jacobian(fn, x, eps=1e-8):
+        f0 = fn(x)
+        n_res = len(f0)
+        n_params = len(x)
+        jac = np.zeros((n_res, n_params))
+        for i in range(n_params):
+            x_plus = x.copy()
+            x_plus[i] += eps
+            jac[:, i] = (fn(x_plus) - f0) / eps
+        return jac
+    
+    # Scipy uses 2-point or 3-point finite differences
+    fd_jac_np = fd_jacobian(numpy_residuals, x0_np)
+    fd_jac_jax = fd_jacobian(jax_residuals, x0_jax)
+    jax_explicit = jax_jacobian(x0_jax)
+    
+    print(f"FD Jacobian (numpy residuals):\n{fd_jac_np}")
+    print(f"\nFD Jacobian (jax residuals):\n{fd_jac_jax}")
+    print(f"\nJAX explicit Jacobian:\n{jax_explicit}")
+    
+    print(f"\nJacobian shapes:")
+    print(f"  FD numpy: {fd_jac_np.shape}, dtype: {fd_jac_np.dtype}")
+    print(f"  FD jax: {fd_jac_jax.shape}, dtype: {fd_jac_jax.dtype}")
+    print(f"  JAX explicit: {jax_explicit.shape}, dtype: {jax_explicit.dtype}")
+    
+    # Check C-contiguous (required by scipy)
+    print(f"\nC-contiguous:")
+    print(f"  FD numpy: {fd_jac_np.flags['C_CONTIGUOUS']}")
+    print(f"  FD jax: {fd_jac_jax.flags['C_CONTIGUOUS']}")
+    print(f"  JAX explicit: {jax_explicit.flags['C_CONTIGUOUS']}")
+    
+    # H8b: Test with forced contiguous array
+    print(f"\n--- H8b: JAX Jacobian with np.ascontiguousarray ---")
+    
+    def jax_jacobian_contiguous(x):
+        jac = jacobian_fn(
+            jnp.array(x, dtype=cache._dtype),
+            target_frame_jax,
+            initial_position_jax
+        )
+        return np.ascontiguousarray(jac)
+    
+    t_cont_start = time.perf_counter()
+    result_cont = scipy.optimize.least_squares(
+        jax_residuals, x0_jax, jac=jax_jacobian_contiguous,
+        bounds=bounds_np
+    )
+    t_cont_end = time.perf_counter()
+    print(f"JAX (contiguous jac): {(t_cont_end - t_cont_start)*1000:.3f} ms, nfev={result_cont.nfev}, njev={result_cont.njev}")
+    
+    # #region agent log
+    log_timing("simple:jax_contiguous_jac", "JAX with contiguous jacobian", {
+        "time_ms": (t_cont_end - t_cont_start) * 1000,
+        "nfev": result_cont.nfev,
+        "njev": result_cont.njev,
+        "hypothesis": "H8"
+    })
+    # #endregion
+    
+    # H9: Check scipy optimization status and cost
+    print(f"\n--- H9: Scipy optimization details ---")
+    print(f"NumPy:")
+    print(f"  status: {result_np.status}, message: {result_np.message}")
+    print(f"  cost: {result_np.cost}, optimality: {result_np.optimality}")
+    print(f"  x: {result_np.x}")
+    
+    print(f"\nJAX (explicit jac):")
+    print(f"  status: {result_jax.status}, message: {result_jax.message}")
+    print(f"  cost: {result_jax.cost}, optimality: {result_jax.optimality}")
+    print(f"  x: {result_jax.x}")
+    
+    print(f"\nJAX (auto jac):")
+    print(f"  status: {result_auto.status}, message: {result_auto.message}")
+    print(f"  cost: {result_auto.cost}, optimality: {result_auto.optimality}")
+    print(f"  x: {result_auto.x}")
+    
+    # #region agent log
+    log_timing("simple:scipy_status", "Scipy optimization status comparison", {
+        "numpy_status": result_np.status,
+        "numpy_cost": float(result_np.cost),
+        "numpy_x": result_np.x.tolist(),
+        "jax_explicit_status": result_jax.status,
+        "jax_explicit_cost": float(result_jax.cost),
+        "jax_explicit_x": result_jax.x.tolist(),
+        "jax_auto_status": result_auto.status,
+        "jax_auto_cost": float(result_auto.cost),
+        "jax_auto_x": result_auto.x.tolist(),
+        "hypothesis": "H9"
+    })
+    # #endregion
+    
+    # H9b: Check if target is reachable - what's the actual workspace?
+    print(f"\n--- H9b: Workspace check ---")
+    # Find FK at zero position
+    fk_zero = simple_chain.forward_kinematics([0]*len(simple_chain.links))[:3, 3]
+    print(f"FK at zero position: {fk_zero}")
+    print(f"Target: {target}")
+    print(f"Distance to target from zero: {np.linalg.norm(fk_zero - target)*100:.2f} cm")
+    
+    # Check chain length (approximate reachability)
+    link_lengths = [link.length for link in simple_chain.links]
+    print(f"Link lengths: {link_lengths}")
+    print(f"Total chain length: {sum(link_lengths):.3f} m")
+
+
+def investigate_scipy_iterations():
+    """
+    Deep investigation into why scipy does more iterations with explicit Jacobian.
+    """
+    import scipy.optimize
+    import jax.numpy as jnp
+    
+    print(f"\n{'='*70}")
+    print("INVESTIGATION: Why does scipy do more iterations with explicit Jacobian?")
+    print(f"{'='*70}")
+    
+    # Load Poppy Torso (the problematic chain)
+    urdf_path = os.path.join(os.path.dirname(__file__), "../resources/poppy_torso/poppy_torso.URDF")
+    simple_chain = chain.Chain.from_urdf_file(
+        urdf_path,
+        base_elements=[
+            "base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x",
+            "chest", "r_shoulder_y"
+        ],
+        last_link_vector=[0, 0.18, 0],
+        active_links_mask=[
+            False, False, False, False, True, True, True, True, False
+        ]
+    )
+    
+    target = [0.1, -0.2, 0.1]
+    initial_position = [0.0] * len(simple_chain.links)
+    
+    # Warmup JAX
+    _ = simple_chain.jax_cache
+    
+    cache = simple_chain.jax_cache
+    target_frame = np.eye(4)
+    target_frame[:3, 3] = target
+    target_frame_jax = jnp.array(target_frame, dtype=cache._dtype)
+    initial_position_jax = jnp.array(initial_position, dtype=cache._dtype)
+    
+    # Setup functions
+    def numpy_residuals(x):
+        full_joints = simple_chain.active_to_full(x, initial_position)
+        fk = simple_chain.forward_kinematics(full_joints, backend="numpy")
+        return fk[:3, 3] - target
+    
+    residual_fn = cache._ik_residuals[(None, False)]
+    jacobian_fn = cache._ik_jacobian[(None, False)]
+    
+    def jax_residuals(x):
+        return np.array(residual_fn(
+            jnp.array(x, dtype=cache._dtype),
+            target_frame_jax,
+            initial_position_jax
+        ))
+    
+    def jax_jacobian(x):
+        return np.array(jacobian_fn(
+            jnp.array(x, dtype=cache._dtype),
+            target_frame_jax,
+            initial_position_jax
+        ))
+    
+    x0 = simple_chain.active_from_full(initial_position)
+    bounds = np.array([link.bounds for link in simple_chain.links])
+    bounds = simple_chain.active_from_full(bounds)
+    bounds = np.moveaxis(bounds, -1, 0)
+    
+    # ========================================
+    # H1 & H2: Track iteration-by-iteration behavior
+    # ========================================
+    print("\n--- Tracking iteration-by-iteration behavior ---")
+    
+    # Custom callback to track iterations
+    iteration_data_no_jac = []
+    iteration_data_with_jac = []
+    
+    def make_tracker(data_list, residual_func):
+        call_count = [0]
+        def track_residuals(x):
+            r = residual_func(x)
+            cost = 0.5 * np.sum(r**2)
+            data_list.append({
+                'call': call_count[0],
+                'x': x.copy(),
+                'cost': cost,
+                'residual_norm': np.linalg.norm(r)
+            })
+            call_count[0] += 1
+            return r
+        return track_residuals
+    
+    # Run without explicit jacobian
+    tracked_jax_no_jac = make_tracker(iteration_data_no_jac, jax_residuals)
+    result_no_jac = scipy.optimize.least_squares(
+        tracked_jax_no_jac, x0.copy(), bounds=bounds, verbose=0
+    )
+    
+    # Run with explicit jacobian
+    tracked_jax_with_jac = make_tracker(iteration_data_with_jac, jax_residuals)
+    result_with_jac = scipy.optimize.least_squares(
+        tracked_jax_with_jac, x0.copy(), jac=jax_jacobian, bounds=bounds, verbose=0
+    )
+    
+    print(f"\nWithout explicit Jacobian: {len(iteration_data_no_jac)} function calls")
+    print(f"With explicit Jacobian: {len(iteration_data_with_jac)} function calls")
+    
+    # ========================================
+    # Analyze convergence paths
+    # ========================================
+    print("\n--- Cost evolution (first 20 calls) ---")
+    print(f"{'Call':<6} {'No Jac Cost':<15} {'With Jac Cost':<15} {'Diff':<15}")
+    print("-" * 55)
+    
+    max_calls = min(20, len(iteration_data_no_jac), len(iteration_data_with_jac))
+    for i in range(max_calls):
+        cost_no = iteration_data_no_jac[i]['cost']
+        cost_with = iteration_data_with_jac[i]['cost']
+        diff = cost_with - cost_no
+        print(f"{i:<6} {cost_no:<15.6e} {cost_with:<15.6e} {diff:<15.6e}")
+    
+    # ========================================
+    # H2: Check trust region behavior via verbose output
+    # ========================================
+    print("\n--- Trust Region Analysis (verbose=2) ---")
+    print("\nWithout explicit Jacobian:")
+    result_verbose_no = scipy.optimize.least_squares(
+        jax_residuals, x0.copy(), bounds=bounds, verbose=2, max_nfev=30
+    )
+    
+    print("\nWith explicit Jacobian:")
+    result_verbose_with = scipy.optimize.least_squares(
+        jax_residuals, x0.copy(), jac=jax_jacobian, bounds=bounds, verbose=2, max_nfev=30
+    )
+    
+    # ========================================
+    # H3: Check if scaling matters
+    # ========================================
+    print("\n--- H3: Effect of x_scale ---")
+    
+    # Test with different x_scale options
+    for x_scale in ['jac', [1.0]*4]:
+        result_scale = scipy.optimize.least_squares(
+            jax_residuals, x0.copy(), jac=jax_jacobian, bounds=bounds,
+            x_scale=x_scale if isinstance(x_scale, str) else np.array(x_scale)
+        )
+        scale_name = x_scale if isinstance(x_scale, str) else 'manual [1,1,1,1]'
+        print(f"x_scale={scale_name}: nfev={result_scale.nfev}, cost={result_scale.cost:.6e}")
+    
+    # ========================================
+    # H4: Check finite difference method
+    # ========================================
+    print("\n--- H4: Finite difference method comparison ---")
+    
+    for diff_step in [None, 1e-8, 1e-6, 1e-4]:
+        result_fd = scipy.optimize.least_squares(
+            jax_residuals, x0.copy(), bounds=bounds, diff_step=diff_step
+        )
+        step_name = 'default' if diff_step is None else f'{diff_step}'
+        print(f"diff_step={step_name}: nfev={result_fd.nfev}, cost={result_fd.cost:.6e}")
+    
+    # ========================================
+    # Key insight: Compare Jacobian at different points
+    # ========================================
+    print("\n--- Jacobian comparison at multiple points ---")
+    
+    # Compare at x0
+    jac_explicit_x0 = jax_jacobian(x0)
+    
+    # Scipy's internal FD jacobian approximation
+    eps = np.sqrt(np.finfo(float).eps)  # scipy's default
+    jac_fd_x0 = np.zeros_like(jac_explicit_x0)
+    f0 = jax_residuals(x0)
+    for i in range(len(x0)):
+        x_plus = x0.copy()
+        h = eps * max(1.0, abs(x0[i]))
+        x_plus[i] += h
+        jac_fd_x0[:, i] = (jax_residuals(x_plus) - f0) / h
+    
+    print(f"Scipy default eps: {eps}")
+    print(f"\nJacobian at x0 (explicit):\n{jac_explicit_x0}")
+    print(f"\nJacobian at x0 (FD with scipy's eps):\n{jac_fd_x0}")
+    print(f"\nDifference:\n{jac_explicit_x0 - jac_fd_x0}")
+    print(f"Max abs diff: {np.max(np.abs(jac_explicit_x0 - jac_fd_x0)):.2e}")
+    
+    # Condition number
+    print(f"\nCondition number (explicit): {np.linalg.cond(jac_explicit_x0):.2e}")
+    print(f"Condition number (FD): {np.linalg.cond(jac_fd_x0):.2e}")
+    
+    # #region agent log
+    log_timing("investigation:summary", "Investigation summary", {
+        "nfev_no_jac": result_no_jac.nfev,
+        "nfev_with_jac": result_with_jac.nfev,
+        "cost_no_jac": float(result_no_jac.cost),
+        "cost_with_jac": float(result_with_jac.cost),
+        "cond_explicit": float(np.linalg.cond(jac_explicit_x0)),
+        "cond_fd": float(np.linalg.cond(jac_fd_x0)),
+        "hypothesis": "investigation"
+    })
+    # #endregion
+
+
+def test_analytical_jacobian_option():
+    """
+    Test the new use_analytical_jacobian option.
+    """
+    print(f"\n{'='*70}")
+    print("TEST: use_analytical_jacobian option")
+    print(f"{'='*70}")
+    
+    # Load Poppy Torso (the problematic chain)
+    urdf_path = os.path.join(os.path.dirname(__file__), "../resources/poppy_torso/poppy_torso.URDF")
+    simple_chain = chain.Chain.from_urdf_file(
+        urdf_path,
+        base_elements=[
+            "base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x",
+            "chest", "r_shoulder_y"
+        ],
+        last_link_vector=[0, 0.18, 0],
+        active_links_mask=[
+            False, False, False, False, True, True, True, True, False
+        ]
+    )
+    
+    target = [0.1, -0.2, 0.1]
+    
+    # Warmup
+    _ = simple_chain.inverse_kinematics(target_position=target, backend="jax", optimizer="scipy")
+    
+    # Test with analytical Jacobian (default)
+    t1_start = time.perf_counter()
+    for _ in range(10):
+        result1 = simple_chain.inverse_kinematics(
+            target_position=target, 
+            backend="jax", 
+            optimizer="scipy",
+            use_analytical_jacobian=True
+        )
+    t1_end = time.perf_counter()
+    
+    # Test without analytical Jacobian
+    t2_start = time.perf_counter()
+    for _ in range(10):
+        result2 = simple_chain.inverse_kinematics(
+            target_position=target, 
+            backend="jax", 
+            optimizer="scipy",
+            use_analytical_jacobian=False
+        )
+    t2_end = time.perf_counter()
+    
+    time_analytical = (t1_end - t1_start) / 10 * 1000
+    time_fd = (t2_end - t2_start) / 10 * 1000
+    
+    print(f"\nPoppy Torso - JAX scipy optimizer:")
+    print(f"  With analytical Jacobian:    {time_analytical:.2f} ms/call")
+    print(f"  Without (finite diff):       {time_fd:.2f} ms/call")
+    print(f"  Speedup with FD:             {time_analytical/time_fd:.2f}x")
+    
+    # Verify results are similar
+    fk1 = simple_chain.forward_kinematics(result1)[:3, 3]
+    fk2 = simple_chain.forward_kinematics(result2)[:3, 3]
+    print(f"\nPosition errors:")
+    print(f"  Analytical Jacobian: {np.linalg.norm(fk1 - target)*1000:.4f} mm")
+    print(f"  Finite diff:         {np.linalg.norm(fk2 - target)*1000:.4f} mm")
+    
+    # #region agent log
+    log_timing("test:analytical_jacobian", "Analytical Jacobian option test", {
+        "time_analytical_ms": time_analytical,
+        "time_fd_ms": time_fd,
+        "speedup": time_analytical / time_fd,
+        "error_analytical_mm": float(np.linalg.norm(fk1 - target)*1000),
+        "error_fd_mm": float(np.linalg.norm(fk2 - target)*1000),
+        "hypothesis": "solution"
+    })
+    # #endregion
+
+
+def test_scipy_options():
+    """
+    Test different scipy.optimize.least_squares options to improve convergence
+    with analytical Jacobian.
+    """
+    import scipy.optimize
+    import jax.numpy as jnp
+    
+    print(f"\n{'='*70}")
+    print("TEST: Scipy options to fix analytical Jacobian convergence")
+    print(f"{'='*70}")
+    
+    # Load Poppy Torso
+    urdf_path = os.path.join(os.path.dirname(__file__), "../resources/poppy_torso/poppy_torso.URDF")
+    poppy = chain.Chain.from_urdf_file(
+        urdf_path,
+        base_elements=["base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x", "chest", "r_shoulder_y"],
+        last_link_vector=[0, 0.18, 0],
+        active_links_mask=[False, False, False, False, True, True, True, True, False]
+    )
+    
+    target = [0.1, -0.2, 0.1]
+    initial_position = [0.0] * len(poppy.links)
+    
+    # Warmup JAX
+    _ = poppy.jax_cache
+    cache = poppy.jax_cache
+    
+    target_frame = np.eye(4)
+    target_frame[:3, 3] = target
+    target_frame_jax = jnp.array(target_frame, dtype=cache._dtype)
+    initial_jax = jnp.array(initial_position, dtype=cache._dtype)
+    
+    residual_fn = cache._ik_residuals[(None, False)]
+    jacobian_fn = cache._ik_jacobian[(None, False)]
+    
+    def jax_res(x):
+        return np.array(residual_fn(jnp.array(x, dtype=cache._dtype), target_frame_jax, initial_jax))
+    
+    def jax_jac(x):
+        return np.array(jacobian_fn(jnp.array(x, dtype=cache._dtype), target_frame_jax, initial_jax))
+    
+    x0 = poppy.active_from_full(initial_position)
+    bounds = np.array([link.bounds for link in poppy.links])
+    bounds = poppy.active_from_full(bounds)
+    bounds = np.moveaxis(bounds, -1, 0)
+    
+    print(f"\nBaseline (no Jacobian): ", end="")
+    r_base = scipy.optimize.least_squares(jax_res, x0.copy(), bounds=bounds)
+    print(f"nfev={r_base.nfev}, cost={r_base.cost:.2e}")
+    
+    print(f"Baseline (with Jacobian): ", end="")
+    r_jac = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds)
+    print(f"nfev={r_jac.nfev}, cost={r_jac.cost:.2e}")
+    
+    print(f"\n{'='*70}")
+    print("Testing different options with analytical Jacobian:")
+    print(f"{'='*70}\n")
+    
+    # Test 1: x_scale='jac' (auto-scaling based on Jacobian)
+    print("1. x_scale='jac' (auto-scaling): ", end="")
+    r1 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds, x_scale='jac')
+    print(f"nfev={r1.nfev}, cost={r1.cost:.2e}")
+    
+    # Test 2: Different tr_solver
+    print("2. tr_solver='lsmr': ", end="")
+    r2 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds, tr_solver='lsmr')
+    print(f"nfev={r2.nfev}, cost={r2.cost:.2e}")
+    
+    # Test 3: Relaxed tolerances
+    print("3. ftol=1e-4, xtol=1e-4: ", end="")
+    r3 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds, ftol=1e-4, xtol=1e-4)
+    print(f"nfev={r3.nfev}, cost={r3.cost:.2e}")
+    
+    # Test 4: Robust loss function (soft_l1)
+    print("4. loss='soft_l1': ", end="")
+    r4 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds, loss='soft_l1')
+    print(f"nfev={r4.nfev}, cost={r4.cost:.2e}")
+    
+    # Test 5: Robust loss function (huber)
+    print("5. loss='huber': ", end="")
+    r5 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds, loss='huber')
+    print(f"nfev={r5.nfev}, cost={r5.cost:.2e}")
+    
+    # Test 6: Combination x_scale + relaxed tol
+    print("6. x_scale='jac' + ftol=1e-4: ", end="")
+    r6 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds, x_scale='jac', ftol=1e-4)
+    print(f"nfev={r6.nfev}, cost={r6.cost:.2e}")
+    
+    # Test 7: dogbox method instead of trf
+    print("7. method='dogbox': ", end="")
+    r7 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, bounds=bounds, method='dogbox')
+    print(f"nfev={r7.nfev}, cost={r7.cost:.2e}")
+    
+    # Test 8: lm method (no bounds support, so skip bounds)
+    print("8. method='lm' (no bounds): ", end="")
+    r8 = scipy.optimize.least_squares(jax_res, x0.copy(), jac=jax_jac, method='lm')
+    print(f"nfev={r8.nfev}, cost={r8.cost:.2e}")
+    
+    # Find best option
+    results = [
+        ("baseline (no jac)", r_base),
+        ("baseline (with jac)", r_jac),
+        ("x_scale='jac'", r1),
+        ("tr_solver='lsmr'", r2),
+        ("relaxed tol", r3),
+        ("loss='soft_l1'", r4),
+        ("loss='huber'", r5),
+        ("x_scale + tol", r6),
+        ("method='dogbox'", r7),
+        ("method='lm'", r8),
+    ]
+    
+    print(f"\n{'='*70}")
+    print("SUMMARY (sorted by nfev):")
+    print(f"{'='*70}")
+    for name, r in sorted(results, key=lambda x: x[1].nfev):
+        fk = poppy.forward_kinematics(poppy.active_to_full(r.x, initial_position))[:3, 3]
+        err = np.linalg.norm(fk - target) * 1000
+        print(f"{name:25s}: nfev={r.nfev:3d}, cost={r.cost:.2e}, error={err:.4f}mm")
+
+
+def test_new_scipy_params():
+    """Test the new scipy parameters in the JAX backend."""
+    print(f"\n{'='*70}")
+    print("TEST: New scipy parameters in JAX backend")
+    print(f"{'='*70}")
+    
+    # Load Poppy Torso
+    urdf_path = os.path.join(os.path.dirname(__file__), "../resources/poppy_torso/poppy_torso.URDF")
+    poppy = chain.Chain.from_urdf_file(
+        urdf_path,
+        base_elements=["base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x", "chest", "r_shoulder_y"],
+        last_link_vector=[0, 0.18, 0],
+        active_links_mask=[False, False, False, False, True, True, True, True, False]
+    )
+    
+    target = [0.1, -0.2, 0.1]
+    
+    # Warmup
+    _ = poppy.inverse_kinematics(target_position=target, backend="jax")
+    
+    configs = [
+        {"name": "NumPy baseline", "backend": "numpy"},
+        {"name": "JAX + FD (no analytical)", "backend": "jax", "use_analytical_jacobian": False},
+        {"name": "JAX default (analytical)", "backend": "jax"},
+        {"name": "JAX + x_scale='jac'", "backend": "jax", "scipy_x_scale": "jac"},
+        {"name": "JAX + gtol=1e-6", "backend": "jax", "scipy_gtol": 1e-6},
+        {"name": "JAX + tr_solver='lsmr'", "backend": "jax", "scipy_tr_solver": "lsmr"},
+        {"name": "JAX + lsmr + regularize", "backend": "jax", "scipy_tr_solver": "lsmr", "scipy_tr_options": {"regularize": True}},
+        {"name": "JAX + method='dogbox'", "backend": "jax", "scipy_method": "dogbox"},
+        {"name": "JAX + x_scale + gtol", "backend": "jax", "scipy_x_scale": "jac", "scipy_gtol": 1e-6},
+        {"name": "JAX optimal combo", "backend": "jax", "scipy_x_scale": "jac", "scipy_gtol": 1e-6, "scipy_tr_solver": "lsmr", "scipy_tr_options": {"regularize": True}},
+    ]
+    
+    print(f"\n{'Config':<30} {'Time (ms)':<12} {'Error (mm)':<12}")
+    print("-" * 55)
+    
+    for cfg in configs:
+        name = cfg.pop("name")
+        
+        # Time 10 iterations
+        t_start = time.perf_counter()
+        for _ in range(10):
+            result = poppy.inverse_kinematics(target_position=target, **cfg)
+        t_end = time.perf_counter()
+        
+        avg_time = (t_end - t_start) / 10 * 1000
+        
+        # Check error
+        fk = poppy.forward_kinematics(result)[:3, 3]
+        error = np.linalg.norm(fk - target) * 1000
+        
+        print(f"{name:<30} {avg_time:<12.2f} {error:<12.4f}")
+        
+        # Restore name for next iteration
+        cfg["name"] = name
+
+
+if __name__ == "__main__":
+    if not JAX_AVAILABLE:
+        print("JAX is not available. Please install JAX to run this profiling.")
+        exit(1)
+    
+    test_new_scipy_params()

--- a/tests/test_jax_backend.py
+++ b/tests/test_jax_backend.py
@@ -308,15 +308,15 @@ class TestPerformance:
             _ = simple_chain.inverse_kinematics(target_position=target, backend="numpy")
         numpy_time = time.perf_counter() - start
 
-        # Benchmark JAX (gradient_descent)
+        # Benchmark JAX (adam)
         start = time.perf_counter()
         for _ in range(n_iterations):
             _ = simple_chain.inverse_kinematics(
                 target_position=target,
                 backend="jax",
-                optimizer="gradient_descent",
+                optimizer="adam",
                 max_iter=200,
-                learning_rate=0.1
+                learning_rate=0.05
             )
         jax_time = time.perf_counter() - start
 
@@ -324,7 +324,7 @@ class TestPerformance:
         print(f"Inverse Kinematics Benchmark ({n_iterations} iterations)")
         print(f"{'='*60}")
         print(f"NumPy (scipy least_squares): {numpy_time*1000:.2f} ms total, {numpy_time/n_iterations*1000:.2f} ms/call")
-        print(f"JAX (gradient_descent):      {jax_time*1000:.2f} ms total, {jax_time/n_iterations*1000:.2f} ms/call")
+        print(f"JAX (adam):                  {jax_time*1000:.2f} ms total, {jax_time/n_iterations*1000:.2f} ms/call")
         print(f"Speedup: {numpy_time/jax_time:.2f}x")
         print(f"{'='*60}")
 
@@ -332,7 +332,7 @@ class TestPerformance:
         ik_numpy = simple_chain.inverse_kinematics(target_position=target, backend="numpy")
         ik_jax = simple_chain.inverse_kinematics(
             target_position=target, backend="jax",
-            optimizer="gradient_descent", max_iter=200, learning_rate=0.1
+            optimizer="adam", max_iter=200, learning_rate=0.05
         )
 
         fk_numpy = simple_chain.forward_kinematics(ik_numpy)[:3, 3]

--- a/tests/test_jax_backend.py
+++ b/tests/test_jax_backend.py
@@ -72,22 +72,20 @@ class TestForwardKinematics:
 class TestInverseKinematics:
     """Tests for inverse kinematics with JAX backend"""
     
-    def test_ik_lbfgsb(self, simple_chain):
-        """Test IK with L-BFGS-B optimizer"""
+    def test_ik_default(self, simple_chain):
+        """Test IK with default optimizer (adam)"""
         target = [0.1, -0.2, 0.1]
         
         ik_result = simple_chain.inverse_kinematics(
             target_position=target, 
             backend="jax",
-            optimizer="L-BFGS-B",
-            max_iter=200
+            max_iter=500
         )
         
         # Verify the result reaches the target
         fk_result = simple_chain.forward_kinematics(ik_result, backend="jax")[:3, 3]
         error = np.linalg.norm(fk_result - target)
         
-        # Allow for some error since JAX optimizer may not converge as well
         assert error < 0.2, f"IK error too high: {error}"
     
     def test_ik_gradient_descent(self, simple_chain):
@@ -142,6 +140,152 @@ class TestJaxCache:
         cache2 = simple_chain.jax_cache
         
         assert cache1 is cache2
+
+
+class TestAOTCompilation:
+    """Tests for AOT (Ahead-of-Time) compilation using lower/compile"""
+    
+    def test_fk_aot_compiled(self, simple_chain):
+        """Test that FK functions are AOT compiled"""
+        cache = simple_chain.jax_cache
+        
+        # Check that compiled functions exist (not None)
+        assert cache._fk_compiled is not None
+        assert cache._fk_full_compiled is not None
+        
+        # Check they are not JIT functions (they should be CompiledFunction)
+        # CompiledFunction doesn't have the 'lower' method that jit functions have
+        assert not hasattr(cache._fk_compiled, 'lower')
+        assert not hasattr(cache._fk_full_compiled, 'lower')
+    
+    def test_ik_variants_precompiled(self, simple_chain):
+        """Test that IK functions are pre-compiled for all orientation modes"""
+        cache = simple_chain.jax_cache
+        
+        # Expected combinations (excluding no_position=True with orient_mode=None)
+        expected_keys = [
+            (None, False),       # position only
+            ("X", False),        # position + X orientation
+            ("X", True),         # X orientation only
+            ("Y", False),        # position + Y orientation
+            ("Y", True),         # Y orientation only
+            ("Z", False),        # position + Z orientation
+            ("Z", True),         # Z orientation only
+            ("all", False),      # position + all orientation
+            ("all", True),       # all orientation only
+        ]
+        
+        for key in expected_keys:
+            assert key in cache._ik_compiled, f"Missing compiled IK for {key}"
+            # Check it's a CompiledFunction (no 'lower' method)
+            assert not hasattr(cache._ik_compiled[key], 'lower')
+        
+        # The invalid combination should not exist
+        assert (None, True) not in cache._ik_compiled
+    
+    def test_compilation_happens_once(self, simple_chain):
+        """Test that compilation is done once at cache creation, not on each call"""
+        import time
+        
+        # Force cache creation (this does the compilation)
+        cache = simple_chain.jax_cache
+        
+        # Get references to compiled functions
+        fk_compiled_ref = cache._fk_compiled
+        ik_compiled_ref = cache._ik_compiled[(None, False)]
+        
+        # Run multiple FK and IK calls
+        joints = [0.0] * len(simple_chain.links)
+        target = np.eye(4)
+        target[:3, 3] = [0.1, -0.2, 0.1]
+        
+        for _ in range(10):
+            _ = cache.forward_kinematics(joints)
+            _ = cache.inverse_kinematics(target, max_iter=10)
+        
+        # Verify the same compiled functions are still being used
+        assert cache._fk_compiled is fk_compiled_ref
+        assert cache._ik_compiled[(None, False)] is ik_compiled_ref
+    
+    def test_lazy_compilation_fallback(self):
+        """Test that lazy compilation works when precompile=False"""
+        from ikpy import chain as chain_module
+        
+        # Create chain with precompile=False
+        lazy_chain = chain_module.Chain.from_urdf_file(
+            "../resources/poppy_torso/poppy_torso.URDF",
+            base_elements=[
+                "base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x",
+                "chest", "r_shoulder_y"
+            ],
+            last_link_vector=[0, 0.18, 0],
+            active_links_mask=[
+                False, False, False, False, True, True, True, True, False
+            ],
+            jax_precompile=False
+        )
+        
+        cache = lazy_chain.jax_cache
+        
+        # With lazy compilation, _fk_compiled should be None
+        assert cache._fk_compiled is None
+        assert cache._fk_full_compiled is None
+        
+        # But _fk_jit should exist for lazy compilation
+        assert cache._fk_jit is not None
+        assert cache._fk_full_jit is not None
+        
+        # FK should still work (using JIT fallback)
+        joints = [0.0] * len(lazy_chain.links)
+        fk_result = lazy_chain.forward_kinematics(joints, backend="jax")
+        assert fk_result.shape == (4, 4)
+    
+    def test_ik_uses_precompiled_functions(self, simple_chain):
+        """Test that IK actually uses the pre-compiled functions"""
+        cache = simple_chain.jax_cache
+        
+        # Get the pre-compiled function for position-only mode
+        compiled_fn = cache._ik_compiled[(None, False)]
+        
+        # Run IK
+        target = np.eye(4)
+        target[:3, 3] = [0.1, -0.2, 0.1]
+        
+        result = simple_chain.inverse_kinematics(
+            target_position=[0.1, -0.2, 0.1],
+            backend="jax",
+            optimizer="gradient_descent",
+            max_iter=50
+        )
+        
+        # Verify result is valid
+        assert result.shape == (len(simple_chain.links),)
+        
+        # The compiled function should still be the same object
+        assert cache._ik_compiled[(None, False)] is compiled_fn
+    
+    def test_ik_orientation_modes_all_work(self, simple_chain):
+        """Test that IK works for all pre-compiled orientation modes"""
+        target = np.eye(4)
+        target[:3, 3] = [0.1, -0.2, 0.1]
+        target[:3, 0] = [1, 0, 0]  # X axis
+        target[:3, 1] = [0, 1, 0]  # Y axis
+        target[:3, 2] = [0, 0, 1]  # Z axis
+        
+        # Test each orientation mode
+        for orient_mode in [None, "X", "Y", "Z", "all"]:
+            result = simple_chain.inverse_kinematics(
+                target_position=[0.1, -0.2, 0.1],
+                target_orientation=target[:3, 0] if orient_mode == "X" else 
+                                   target[:3, 1] if orient_mode == "Y" else
+                                   target[:3, 2] if orient_mode == "Z" else
+                                   target[:3, :3] if orient_mode == "all" else None,
+                orientation_mode=orient_mode,
+                backend="jax",
+                optimizer="gradient_descent",
+                max_iter=50
+            )
+            assert result.shape == (len(simple_chain.links),), f"Failed for orientation_mode={orient_mode}"
 
 
 class TestPerformance:

--- a/tests/test_jax_backend.py
+++ b/tests/test_jax_backend.py
@@ -308,14 +308,15 @@ class TestPerformance:
             _ = simple_chain.inverse_kinematics(target_position=target, backend="numpy")
         numpy_time = time.perf_counter() - start
 
-        # Benchmark JAX (L-BFGS-B)
+        # Benchmark JAX (gradient_descent)
         start = time.perf_counter()
         for _ in range(n_iterations):
             _ = simple_chain.inverse_kinematics(
                 target_position=target,
                 backend="jax",
-                optimizer="L-BFGS-B",
-                max_iter=100
+                optimizer="gradient_descent",
+                max_iter=200,
+                learning_rate=0.1
             )
         jax_time = time.perf_counter() - start
 
@@ -323,13 +324,16 @@ class TestPerformance:
         print(f"Inverse Kinematics Benchmark ({n_iterations} iterations)")
         print(f"{'='*60}")
         print(f"NumPy (scipy least_squares): {numpy_time*1000:.2f} ms total, {numpy_time/n_iterations*1000:.2f} ms/call")
-        print(f"JAX (L-BFGS-B):              {jax_time*1000:.2f} ms total, {jax_time/n_iterations*1000:.2f} ms/call")
+        print(f"JAX (gradient_descent):      {jax_time*1000:.2f} ms total, {jax_time/n_iterations*1000:.2f} ms/call")
         print(f"Speedup: {numpy_time/jax_time:.2f}x")
         print(f"{'='*60}")
 
         # Verify both reach the target reasonably well
         ik_numpy = simple_chain.inverse_kinematics(target_position=target, backend="numpy")
-        ik_jax = simple_chain.inverse_kinematics(target_position=target, backend="jax", max_iter=100)
+        ik_jax = simple_chain.inverse_kinematics(
+            target_position=target, backend="jax",
+            optimizer="gradient_descent", max_iter=200, learning_rate=0.1
+        )
 
         fk_numpy = simple_chain.forward_kinematics(ik_numpy)[:3, 3]
         fk_jax = simple_chain.forward_kinematics(ik_jax)[:3, 3]

--- a/tests/test_jax_backend.py
+++ b/tests/test_jax_backend.py
@@ -144,5 +144,203 @@ class TestJaxCache:
         assert cache1 is cache2
 
 
+class TestPerformance:
+    """Performance comparison tests between NumPy and JAX backends"""
+
+    def test_jacobian_computation_speed(self, simple_chain):
+        """Compare Jacobian computation - JAX autodiff vs numerical differentiation"""
+        import time
+        import jax.numpy as jnp
+        from jax import jacfwd, jit
+
+        joints = np.array([0.0] * len(simple_chain.links))
+        joints[4] = 0.5
+        joints[5] = -0.3
+
+        n_iterations = 100
+
+        # NumPy: Numerical Jacobian (finite differences)
+        def numerical_jacobian(chain, joints, eps=1e-6):
+            n_joints = len(joints)
+            fk_base = chain.forward_kinematics(joints, backend="numpy")[:3, 3]
+            jacobian = np.zeros((3, n_joints))
+            for i in range(n_joints):
+                joints_perturbed = joints.copy()
+                joints_perturbed[i] += eps
+                fk_perturbed = chain.forward_kinematics(joints_perturbed, backend="numpy")[:3, 3]
+                jacobian[:, i] = (fk_perturbed - fk_base) / eps
+            return jacobian
+
+        start = time.perf_counter()
+        for _ in range(n_iterations):
+            jac_numpy = numerical_jacobian(simple_chain, joints)
+        numpy_time = time.perf_counter() - start
+
+        # JAX: Automatic differentiation with JIT
+        from ikpy.jax_backend import forward_kinematics_jax, extract_chain_parameters
+        chain_params = extract_chain_parameters(simple_chain)
+
+        def fk_position(joints_jax):
+            return forward_kinematics_jax(joints_jax, chain_params)[:3, 3]
+
+        # JIT compile the Jacobian function
+        jac_fn = jit(jacfwd(fk_position))
+
+        # Warm-up and compile
+        joints_jax = jnp.array(joints)
+        _ = jac_fn(joints_jax).block_until_ready()
+
+        start = time.perf_counter()
+        for _ in range(n_iterations):
+            jac_jax = jac_fn(joints_jax).block_until_ready()
+        jax_time = time.perf_counter() - start
+
+        print(f"\n{'='*60}")
+        print(f"Jacobian Computation ({n_iterations} iterations)")
+        print(f"{'='*60}")
+        print(f"NumPy (finite diff): {numpy_time*1000:.2f} ms total, {numpy_time/n_iterations*1000:.4f} ms/call")
+        print(f"JAX (jit+autodiff):  {jax_time*1000:.2f} ms total, {jax_time/n_iterations*1000:.4f} ms/call")
+        print(f"Speedup:             {numpy_time/jax_time:.2f}x")
+        print(f"{'='*60}")
+
+        # Verify Jacobians are similar
+        np.testing.assert_allclose(jac_numpy, np.array(jac_jax), rtol=1e-3, atol=1e-3)
+        print("✓ Jacobians match!")
+
+    def test_forward_kinematics_batched_speed(self, simple_chain):
+        """Compare batched FK speed - where JAX really shines"""
+        import time
+        import jax.numpy as jnp
+        from jax import vmap
+
+        n_configs = 1000  # Number of joint configurations to evaluate
+
+        # Generate random joint configurations
+        np.random.seed(42)
+        all_joints = np.random.uniform(-1, 1, (n_configs, len(simple_chain.links)))
+
+        # NumPy: loop over configurations
+        start = time.perf_counter()
+        results_numpy = []
+        for joints in all_joints:
+            fk = simple_chain.forward_kinematics(joints.tolist(), backend="numpy")
+            results_numpy.append(fk[:3, 3])
+        results_numpy = np.array(results_numpy)
+        numpy_time = time.perf_counter() - start
+
+        # JAX: vectorized with vmap
+        from ikpy.jax_backend import forward_kinematics_jax, extract_chain_parameters
+        chain_params = extract_chain_parameters(simple_chain)
+
+        # Create batched FK function
+        batched_fk = vmap(lambda j: forward_kinematics_jax(j, chain_params))
+
+        # Warm-up
+        _ = batched_fk(jnp.array(all_joints[:10])).block_until_ready()
+
+        start = time.perf_counter()
+        all_joints_jax = jnp.array(all_joints)
+        results_jax = batched_fk(all_joints_jax)[:, :3, 3].block_until_ready()
+        jax_time = time.perf_counter() - start
+
+        print(f"\n{'='*60}")
+        print(f"BATCHED Forward Kinematics ({n_configs} configurations)")
+        print(f"{'='*60}")
+        print(f"NumPy (loop):      {numpy_time*1000:.2f} ms")
+        print(f"JAX (vmap):        {jax_time*1000:.2f} ms")
+        print(f"Speedup:           {numpy_time/jax_time:.2f}x")
+        print(f"{'='*60}")
+
+        # Verify results match
+        np.testing.assert_allclose(results_numpy, np.array(results_jax), rtol=1e-4, atol=1e-4)
+
+    def test_forward_kinematics_speed(self, simple_chain):
+        """Compare FK speed between NumPy and JAX"""
+        import time
+
+        joints = [0.0] * len(simple_chain.links)
+        joints[4] = 0.5
+        joints[5] = -0.3
+
+        n_iterations = 1000
+
+        # Warm-up JAX (first call triggers compilation if not precompiled)
+        _ = simple_chain.forward_kinematics(joints, backend="jax")
+
+        # Benchmark NumPy
+        start = time.perf_counter()
+        for _ in range(n_iterations):
+            _ = simple_chain.forward_kinematics(joints, backend="numpy")
+        numpy_time = time.perf_counter() - start
+
+        # Benchmark JAX
+        start = time.perf_counter()
+        for _ in range(n_iterations):
+            _ = simple_chain.forward_kinematics(joints, backend="jax")
+        jax_time = time.perf_counter() - start
+
+        print(f"\n{'='*60}")
+        print(f"Forward Kinematics Benchmark ({n_iterations} iterations)")
+        print(f"{'='*60}")
+        print(f"NumPy: {numpy_time*1000:.2f} ms total, {numpy_time/n_iterations*1000:.4f} ms/call")
+        print(f"JAX:   {jax_time*1000:.2f} ms total, {jax_time/n_iterations*1000:.4f} ms/call")
+        print(f"Speedup: {numpy_time/jax_time:.2f}x")
+        print(f"{'='*60}")
+
+        # Just verify both produce same results
+        fk_numpy = simple_chain.forward_kinematics(joints, backend="numpy")
+        fk_jax = simple_chain.forward_kinematics(joints, backend="jax")
+        np.testing.assert_allclose(fk_numpy, fk_jax, rtol=1e-5, atol=1e-5)
+
+    def test_inverse_kinematics_speed(self, simple_chain):
+        """Compare IK speed between NumPy and JAX"""
+        import time
+
+        target = [0.1, -0.2, 0.1]
+        n_iterations = 10  # IK is slower, use fewer iterations
+
+        # Warm-up JAX
+        _ = simple_chain.inverse_kinematics(target_position=target, backend="jax", max_iter=50)
+
+        # Benchmark NumPy
+        start = time.perf_counter()
+        for _ in range(n_iterations):
+            _ = simple_chain.inverse_kinematics(target_position=target, backend="numpy")
+        numpy_time = time.perf_counter() - start
+
+        # Benchmark JAX (L-BFGS-B)
+        start = time.perf_counter()
+        for _ in range(n_iterations):
+            _ = simple_chain.inverse_kinematics(
+                target_position=target,
+                backend="jax",
+                optimizer="L-BFGS-B",
+                max_iter=100
+            )
+        jax_time = time.perf_counter() - start
+
+        print(f"\n{'='*60}")
+        print(f"Inverse Kinematics Benchmark ({n_iterations} iterations)")
+        print(f"{'='*60}")
+        print(f"NumPy (scipy least_squares): {numpy_time*1000:.2f} ms total, {numpy_time/n_iterations*1000:.2f} ms/call")
+        print(f"JAX (L-BFGS-B):              {jax_time*1000:.2f} ms total, {jax_time/n_iterations*1000:.2f} ms/call")
+        print(f"Speedup: {numpy_time/jax_time:.2f}x")
+        print(f"{'='*60}")
+
+        # Verify both reach the target reasonably well
+        ik_numpy = simple_chain.inverse_kinematics(target_position=target, backend="numpy")
+        ik_jax = simple_chain.inverse_kinematics(target_position=target, backend="jax", max_iter=100)
+
+        fk_numpy = simple_chain.forward_kinematics(ik_numpy)[:3, 3]
+        fk_jax = simple_chain.forward_kinematics(ik_jax)[:3, 3]
+
+        error_numpy = np.linalg.norm(fk_numpy - target)
+        error_jax = np.linalg.norm(fk_jax - target)
+
+        print(f"NumPy IK error: {error_numpy:.6f}")
+        print(f"JAX IK error:   {error_jax:.6f}")
+        print(f"{'='*60}")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add a JAX backend for forward and inverse kinematics with **AOT (Ahead-of-Time) compilation** and optimized scipy integration.

### Key Features

- **Analytical Jacobian**: JAX autodiff computes exact Jacobians (vs finite differences)
- **AOT compilation**: All functions compiled once at chain creation
- **Optimized scipy**: Uses `scipy.optimize.least_squares` with `x_scale='jac'` by default
- **Pre-compiled variants**: IK functions pre-compiled for all orientation modes

### Performance Results

#### Single Target

| Robot | NumPy | JAX | Speedup |
|-------|-------|-----|---------|
| Poppy (4 joints) - easy | 5.3 ms | 11.6 ms | 0.45x |
| **Poppy (4 joints) - hard** | 29.9 ms | 10.8 ms | **2.76x** |
| Baxter (7 joints) - easy | 11.3 ms | 8.8 ms | **1.29x** |
| **Baxter (7 joints) - hard** | 48.6 ms | 12.1 ms | **4.00x** |

#### Trajectory Tracking (30 points)

| Robot | Scenario | NumPy | JAX | Speedup | Failures |
|-------|----------|-------|-----|---------|----------|
| Poppy | Cold start | 256 ms | 296 ms | 0.87x | 0/30 |
| Poppy | Warm start | 229 ms | 220 ms | 1.04x | 0/30 |
| **Baxter** | **Cold start** | 816 ms | 232 ms | **3.52x** | 6 vs **0** |
| **Baxter** | **Warm start** | 457 ms | 190 ms | **2.40x** | 0/30 |

### Key Findings

1. **JAX excels on difficult problems**: 2-4x faster on hard targets
2. **More robust**: Fewer local minima failures (6 vs 0 on Baxter cold start)
3. **Best for complex chains**: 2-3.5x faster on robots with 5+ joints
4. **Overhead on easy problems**: ~10ms fixed overhead for simple cases

### Usage

```python
from ikpy import chain

# Create chain (compilation happens here)
my_chain = chain.Chain.from_urdf_file("robot.urdf", ...)

# Use JAX backend (scipy with x_scale='jac' by default)
result = my_chain.inverse_kinematics(
    target_position=[0.5, 0.2, 0.3],
    backend="jax"
)

# Trajectory with warm start (recommended)
current = None
for target in trajectory:
    result = my_chain.inverse_kinematics(
        target_position=target,
        initial_position=current,
        backend="jax"
    )
    current = result
```

### Configuration Options

```python
chain.inverse_kinematics(
    target_position=target,
    backend="jax",
    scipy_method='trf',           # 'trf', 'dogbox', or 'lm'
    scipy_x_scale='jac',          # Auto-scaling (default)
    use_analytical_jacobian=True, # False for finite differences
    scipy_gtol=1e-8,              # Gradient tolerance
)
```

## Test plan

- [x] All existing tests pass
- [x] New AOT compilation tests added
- [x] Performance benchmarks on Poppy and Baxter
- [x] Trajectory tracking tests with warm start
- [x] README documentation updated