### PR TITLE
Add Scarf analytics pixel to track library usage

### DIFF
--- a/src/ikpy/__init__.py
+++ b/src/ikpy/__init__.py
@@ -2,6 +2,7 @@ from ._version import __version__
 
 __all__ = ["__version__"]
 
+
 # Scarf analytics pixel - helps track library usage
 def _scarf_analytics():
     """Download Scarf analytics pixel in background thread."""
@@ -9,19 +10,20 @@ def _scarf_analytics():
         import sys
         from urllib.request import urlopen, Request
         from urllib.parse import urlencode
-        
+
         params = urlencode({
             "x-pxid": "fad6aecc-1efc-4d90-a734-7f629e35c85b",
             "ikpy_version": __version__,
             "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
         })
         url = f"https://static.scarf.sh/a.png?{params}"
-        
+
         req = Request(url, headers={"User-Agent": f"ikpy/{__version__}"})
         urlopen(req, timeout=2)
     except Exception:
         # Silently ignore any errors - analytics should never break the library
         pass
+
 
 try:
     from threading import Thread

--- a/src/ikpy/__init__.py
+++ b/src/ikpy/__init__.py
@@ -1,3 +1,30 @@
 from ._version import __version__
 
 __all__ = ["__version__"]
+
+# Scarf analytics pixel - helps track library usage
+def _scarf_analytics():
+    """Download Scarf analytics pixel in background thread."""
+    try:
+        import sys
+        from urllib.request import urlopen, Request
+        from urllib.parse import urlencode
+        
+        params = urlencode({
+            "x-pxid": "fad6aecc-1efc-4d90-a734-7f629e35c85b",
+            "ikpy_version": __version__,
+            "python_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+        })
+        url = f"https://static.scarf.sh/a.png?{params}"
+        
+        req = Request(url, headers={"User-Agent": f"ikpy/{__version__}"})
+        urlopen(req, timeout=2)
+    except Exception:
+        # Silently ignore any errors - analytics should never break the library
+        pass
+
+try:
+    from threading import Thread
+    Thread(target=_scarf_analytics, daemon=True).start()
+except Exception:
+    pass

--- a/src/ikpy/urdf/URDF.py
+++ b/src/ikpy/urdf/URDF.py
@@ -208,7 +208,7 @@ def get_urdf_parameters(urdf_file, base_elements=None, last_link_vector=None, ba
     base_elements = list(base_elements)
     if base_elements is None:
         base_elements = ["base_link"]
-    elif base_elements is []:
+    elif base_elements == []:
         raise ValueError("base_elements can't be the empty list []")
 
     joints = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-import json
 
 # IKPy imports
 from ikpy.chain import Chain

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,6 +1,4 @@
-import unittest
 import numpy as np
-import sys
 import matplotlib.pyplot as plt
 
 # IKPy imports
@@ -78,7 +76,7 @@ def test_ik_optimization(torso_right_arm):
 
     # Check using the scalar optimizer
     ik = torso_right_arm.inverse_kinematics_frame(
-    frame_target, initial_position=joints, optimizer="scalar")
+        frame_target, initial_position=joints, optimizer="scalar")
     # Check whether the results are almost equal
     np.testing.assert_almost_equal(
         torso_right_arm.forward_kinematics(ik)[:3, 3], target, decimal=3)
@@ -88,4 +86,3 @@ def test_chain_serialization(torso_right_arm):
 
     chain_json_path = torso_right_arm.to_json_file(force=True)
     chain.Chain.from_json_file(chain_json_path)
-

--- a/tests/test_chain_dh.py
+++ b/tests/test_chain_dh.py
@@ -1,5 +1,5 @@
 from ikpy.chain import Chain
-from ikpy.link import OriginLink, DHLink
+from ikpy.link import DHLink
 from ikpy.utils import plot
 
 import matplotlib.pyplot as plt
@@ -7,26 +7,28 @@ import matplotlib.pyplot as plt
 import numpy as np
 from math import pi
 
+
 class UR10():
     def __init__(self):
         self.robot_name = 'UR10'
-        self.home_config = [0, -pi/2, 0, -pi/2, 0, 0] 
+        self.home_config = [0, -pi / 2, 0, -pi / 2, 0, 0]
         self.dh_params = np.array([
-            [  0.1273, 0., pi/2, 0.],
-            [  0., -0.612, 0, 0.],
-            [  0., -0.5723, 0, 0.],
-            [  0.163941, 0.,  pi/2, 0.],
-            [  0.1147, 0.,  -pi/2, 0.],
-            [  0.0922, 0., 0, 0.]])   
-        
-        self.joint_limits =  [
-                        (-360, 360),  
-                        (-360, 360),  
-                        (-360, 360),  
-                        (-360, 360),  
-                        (-360, 360),  
-                        (-360, 360)] 
-        
+            [0.1273, 0., pi / 2, 0.],
+            [0., -0.612, 0, 0.],
+            [0., -0.5723, 0, 0.],
+            [0.163941, 0., pi / 2, 0.],
+            [0.1147, 0., -pi / 2, 0.],
+            [0.0922, 0., 0, 0.]])
+
+        self.joint_limits = [
+            (-360, 360),
+            (-360, 360),
+            (-360, 360),
+            (-360, 360),
+            (-360, 360),
+            (-360, 360)]
+
+
 def create_dh_robot(robot):
     # Create a list of links for the robot
     links = []

--- a/tests/test_orientation.py
+++ b/tests/test_orientation.py
@@ -17,8 +17,9 @@ def test_orientation(baxter_left_arm):
         orientation = baxter_left_arm.forward_kinematics(ik)[:3, axis_index]
 
         # Check
-        ## Note: could be put to 5 decimals, since it works with 5 on local machines and the CI with python > 3.6
-        ## However in order to support 3.6, we put 3 and 4 decimals here...
+        # Note: could be put to 5 decimals, since it works with 5 on local
+        # machines and the CI with python > 3.6
+        # However in order to support 3.6, we put 3 and 4 decimals here...
         np.testing.assert_almost_equal(position, target_position, decimal=3)
         np.testing.assert_almost_equal(orientation, target_orientation, decimal=4)
 
@@ -26,7 +27,7 @@ def test_orientation(baxter_left_arm):
 def test_orientation_full_frame(baxter_left_arm):
     # Found by exploring the reachable values
     target_position = [0.1, 0.5, -0.1]
-    target_orientation = [[0,0,1], [1,0,0], [0,1,0]]
+    target_orientation = [[0, 0, 1], [1, 0, 0], [0, 1, 0]]
 
     # Begin to place the arm in the right position
     ik = baxter_left_arm.inverse_kinematics(target_position)
@@ -38,7 +39,6 @@ def test_orientation_full_frame(baxter_left_arm):
     # Check
     np.testing.assert_almost_equal(orientation, target_orientation, decimal=5)
     np.testing.assert_almost_equal(position, target_position, decimal=5)
-
 
 
 def test_orientation_only(baxter_left_arm):
@@ -59,5 +59,3 @@ def test_orientation_only(baxter_left_arm):
     # At this point, we should get a random position, that is different that the position before
     # So check that they are not equal
     np.testing.assert_raises(AssertionError, np.testing.assert_almost_equal, position, target_position)
-
-

--- a/tests/test_urdf.py
+++ b/tests/test_urdf.py
@@ -34,9 +34,9 @@ def test_urdf_chain(resources_path, interactive):
 def test_urdf_parser(poppy_torso_urdf):
     """Test the correctness of a URDF parser"""
     base_elements = [
-            "base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x",
-            "chest", "r_shoulder_y"
-        ]
+        "base", "abs_z", "spine", "bust_y", "bust_motors", "bust_x",
+        "chest", "r_shoulder_y"
+    ]
     last_link_vector = [0, 0.18, 0]
 
     links = URDF.get_urdf_parameters(poppy_torso_urdf, base_elements=base_elements, last_link_vector=last_link_vector)
@@ -45,7 +45,7 @@ def test_urdf_parser(poppy_torso_urdf):
 
 
 def test_plot_urdf_tree(baxter_urdf):
-    dot = get_urdf_tree(baxter_urdf, root_element="base", out_image_path="./out/baxter")
+    _ = get_urdf_tree(baxter_urdf, root_element="base", out_image_path="./out/baxter")
 
 
 def test_chain_from_joints(poppy_ergo_urdf):


### PR DESCRIPTION
Add a non-blocking Scarf pixel download on import to help track IKPy usage. The pixel includes ikpy_version and python_version parameters for better analytics insights.

- Runs in a background daemon thread to avoid slowing down imports
- Silently ignores any errors (no network, timeout, etc.)
- Uses only Python standard library (urllib, threading)