### PR TITLE
CI / Bump actions/checkout to v7 and actions/setup-python to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: "Checkout branch"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: "Linting test"
@@ -29,10 +29,10 @@ jobs:
         # Note: We need to quote '3.10' and '3.11' otherwise it's interpreted as as number, e.g. 3.1
         python-version: ['3.10', '3.11', '3.12', '3.13']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
         name: "Checkout branch"
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - run: |
@@ -56,9 +56,9 @@ jobs:
     permissions:
         id-token: write
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       # Pip doesn't support building a sdist when in PEP517 mode, so use a dedicated package for this


### PR DESCRIPTION
The `v1` versions of `actions/checkout` and `actions/setup-python` target deprecated Node.js runtimes and trigger deprecation warnings on every CI run. This bumps them to the current major versions (`checkout@v7`, `setup-python@v6`).

No workflow logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)