### PR TITLE
Forward optimizer options to SciPy (#157)

### DIFF
--- a/src/ikpy/inverse_kinematics.py
+++ b/src/ikpy/inverse_kinematics.py
@@ -1,4 +1,6 @@
 # coding= utf8
+import warnings
+
 import scipy.optimize
 import numpy as np
 from . import logs
@@ -15,7 +17,7 @@ except ImportError:
 ORIENTATION_COEFF = 1.
 
 
-def inverse_kinematic_optimization(chain, target_frame, starting_nodes_angles, regularization_parameter=None, max_iter=None, orientation_mode=None, no_position=False, optimizer="least_squares"):
+def inverse_kinematic_optimization(chain, target_frame, starting_nodes_angles, regularization_parameter=None, max_iter=None, orientation_mode=None, no_position=False, optimizer="least_squares", optimizer_kwargs=None):
     """
     Computes the inverse kinematic on the specified target
 
@@ -30,7 +32,8 @@ def inverse_kinematic_optimization(chain, target_frame, starting_nodes_angles, r
     regularization_parameter: float
         The coefficient of the regularization.
     max_iter: int
-        Maximum number of iterations for the optimisation algorithm.
+        Deprecated and ignored: capping the iterations of the optimizer can harm the quality of the
+        IK results. Use `optimizer_kwargs` to give the optimizer a stopping criterion of your own.
     orientation_mode: str
         Orientation to target. Choices:
         * None: No orientation
@@ -44,6 +47,12 @@ def inverse_kinematic_optimization(chain, target_frame, starting_nodes_angles, r
         The optimizer to use. Choices:
         * "least_squares": Use scipy.optimize.least_squares (the default)
         * "scalar": Use scipy.optimize.minimize (the default prior to IKPy 3.3)
+    optimizer_kwargs: dict
+        Optional keyword arguments forwarded as-is to the underlying SciPy optimizer, to trade
+        accuracy for speed. The accepted keys are the ones of the optimizer in use:
+        * "least_squares": :func:`scipy.optimize.least_squares`, e.g. {"max_nfev": 10, "ftol": 1e-4}
+        * "scalar": :func:`scipy.optimize.minimize`, e.g. {"options": {"maxiter": 10}, "tol": 1e-4}
+        The bounds are derived from the chain itself, so they cannot be overridden here.
     """
     if optimizer not in ["least_squares", "scalar"]:
         raise ValueError("Unknown solver: {}".format(optimizer))
@@ -144,17 +153,32 @@ def inverse_kinematic_optimization(chain, target_frame, starting_nodes_angles, r
     logs.logger.info("Bounds: {}".format(real_bounds))
 
     if max_iter is not None:
-        logs.logger.info("max_iter is not used anymore in the IK, using it as a parameter will raise an exception in the future")
+        warnings.warn(
+            "max_iter is not used anymore in the IK, and using it as a parameter will raise an exception in the "
+            "future: capping the iterations can harm the quality of the results. Pass a stopping criterion to the "
+            "optimizer instead, with optimizer_kwargs={'max_nfev': 10} for the \"least_squares\" optimizer or "
+            "optimizer_kwargs={'options': {'maxiter': 10}} for the \"scalar\" one.",
+            DeprecationWarning,
+            stacklevel=2)
+
+    if optimizer_kwargs is None:
+        optimizer_kwargs = {}
+    elif "bounds" in optimizer_kwargs:
+        # The bounds come from the limits of the links, so letting them through would silently
+        # detach the solution from the chain it is supposed to describe
+        raise ValueError("The bounds are derived from the chain and cannot be overridden in optimizer_kwargs")
 
     # least squares optimization
     if optimizer == "scalar":
         def optimize_scalar(x):
             return np.linalg.norm(optimize_total(x))
-        res = scipy.optimize.minimize(optimize_scalar, chain.active_from_full(starting_nodes_angles), bounds=real_bounds)
+        res = scipy.optimize.minimize(
+            optimize_scalar, chain.active_from_full(starting_nodes_angles), bounds=real_bounds, **optimizer_kwargs)
     elif optimizer == "least_squares":
         # We need to unzip the bounds
         real_bounds = np.moveaxis(real_bounds, -1, 0)
-        res = scipy.optimize.least_squares(optimize_total, chain.active_from_full(starting_nodes_angles), bounds=real_bounds)
+        res = scipy.optimize.least_squares(
+            optimize_total, chain.active_from_full(starting_nodes_angles), bounds=real_bounds, **optimizer_kwargs)
 
     if res.status != -1:
         logs.logger.info("Inverse kinematic optimisation OK, termination status: {}".format(res.status))

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,5 +1,6 @@
-import numpy as np
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
 
 # IKPy imports
 from ikpy import chain
@@ -86,3 +87,61 @@ def test_chain_serialization(torso_right_arm):
 
     chain_json_path = torso_right_arm.to_json_file(force=True)
     chain.Chain.from_json_file(chain_json_path)
+
+
+def _target_error(chain, ik, target):
+    """How far the pose reached by the IK ended up from the target"""
+    return np.linalg.norm(chain.forward_kinematics(ik)[:3, 3] - target)
+
+
+def test_ik_optimizer_kwargs_reach_the_least_squares_optimizer(torso_right_arm):
+    """A budget given to the optimizer has to be honoured, not just accepted"""
+    target = [0.1, -0.2, 0.1]
+    joints = [1] * len(torso_right_arm.links)
+    joints[-4] = 0
+    frame_target = np.eye(4)
+    frame_target[:3, 3] = target
+
+    converged = torso_right_arm.inverse_kinematics_frame(frame_target, initial_position=joints)
+    starved = torso_right_arm.inverse_kinematics_frame(
+        frame_target, initial_position=joints, optimizer_kwargs={"max_nfev": 1})
+
+    # Stopping the optimizer after a single evaluation cannot reach the target the full run does,
+    # so a worse result is what proves the argument went through to SciPy
+    assert _target_error(torso_right_arm, starved, target) > _target_error(torso_right_arm, converged, target)
+
+
+def test_ik_optimizer_kwargs_reach_the_scalar_optimizer(torso_right_arm):
+    """The scalar optimizer takes its own keys, nested under "options" the way SciPy wants them"""
+    target = [0.1, -0.2, 0.1]
+    joints = [1] * len(torso_right_arm.links)
+    joints[-4] = 0
+    frame_target = np.eye(4)
+    frame_target[:3, 3] = target
+
+    converged = torso_right_arm.inverse_kinematics_frame(
+        frame_target, initial_position=joints, optimizer="scalar")
+    starved = torso_right_arm.inverse_kinematics_frame(
+        frame_target, initial_position=joints, optimizer="scalar",
+        optimizer_kwargs={"options": {"maxiter": 1}})
+
+    assert _target_error(torso_right_arm, starved, target) > _target_error(torso_right_arm, converged, target)
+
+
+def test_ik_optimizer_kwargs_refuse_to_override_the_bounds(torso_right_arm):
+    """The bounds describe the limits of the links, so they are not the caller's to replace"""
+    frame_target = np.eye(4)
+    frame_target[:3, 3] = [0.1, -0.2, 0.1]
+
+    with pytest.raises(ValueError):
+        torso_right_arm.inverse_kinematics_frame(
+            frame_target, optimizer_kwargs={"bounds": (-1, 1)})
+
+
+def test_max_iter_is_deprecated(torso_right_arm):
+    """max_iter is still accepted and still ignored, but it no longer goes by unnoticed"""
+    frame_target = np.eye(4)
+    frame_target[:3, 3] = [0.1, -0.2, 0.1]
+
+    with pytest.warns(DeprecationWarning, match="optimizer_kwargs"):
+        torso_right_arm.inverse_kinematics_frame(frame_target, max_iter=3)


### PR DESCRIPTION
Adds an `optimizer_kwargs` argument to `inverse_kinematic_optimization`, forwarded as-is to `scipy.optimize.least_squares` or `scipy.optimize.minimize`.

This follows where #157 landed rather than restoring `max_iter`. Capping the iterations harms the quality of the results, which is why it was deactivated, but the real-time use case behind the issue still needs a way to bound the work per solve. Passing the optimizer's own keys keeps the whole SciPy surface reachable, including `ftol` and `xtol` and not only the iteration count.

The JAX backend already exposes `scipy_max_nfev`, `tol` and `scipy_method` this way, so the numpy path now matches it. `chain.py` already forwards its kwargs, so both `inverse_kinematics` and `inverse_kinematics_frame` accept the new argument without a change.

`bounds` is refused, because it is derived from the limits of the links and letting it through would quietly detach the solution from the chain it is meant to describe.

`max_iter` stays accepted and ignored, but its notice moves from a `logger.info`, which is invisible unless logging is configured, to a `DeprecationWarning` naming the argument to use instead. That is the symptom the issue actually reported: it silently did nothing.

### Verification

The tests assert the arguments are honoured rather than merely accepted: a single-evaluation budget has to give a worse result than the converged run, for both optimizers. Suite goes from 51 to 55 passing. The one pre-existing failure, `test_plot_urdf_tree`, needs the graphviz binary and is unrelated.

Two things to flag:

- The existing `test_ik_optimization` still passes `max_iter=3`, so it now emits the new `DeprecationWarning`. Happy to change that test if you would rather it did not.
- If you would prefer `max_iter` routed to `max_nfev` / `maxiter` rather than left deprecated, that is a small change on top of this one.

Tested on Windows with Python 3.12.
