### PR TITLE
CI / Run the test suite with the JAX backend installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,37 @@ jobs:
           cd tests && MATPLOTLIBRC="../ci" pytest ./
         name: "Run the tests"
 
+  test-jax:
+    name: Tests (JAX backend)
+    # The job above installs ikpy without the jax extra, so tests/test_jax_backend.py is skipped
+    # there and the JAX backend goes untested. This job installs it.
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+      matrix:
+        # jax requires Python >= 3.12, so this job cannot follow the matrix of the job above
+        python-version: ['3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v7
+        name: "Checkout branch"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: |
+          pip install numpy
+          pip install .[plot,jax] pytest
+          sudo apt-get update --yes && sudo apt-get install graphviz
+        name: "Install dependencies"
+      - run: |
+          # The whole suite, not only test_jax_backend.py: having jax installed also changes the
+          # path taken by Chain, so the other tests cover more here than they do above
+          cd tests && MATPLOTLIBRC="../ci" pytest ./
+        name: "Run the tests"
+
   publish:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, test-jax]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     name: Publish the package to PyPI
     environment:


### PR DESCRIPTION
The `test` job installs `.[plot]`, without the jax extra, so `tests/test_jax_backend.py` is skipped in full. The JAX backend shipped in v4.0.0 has never been exercised by CI, and the 13 tests added in v4.1.0 for `optimizer_budget` / `tol` only ever ran locally — the four green jobs on the v4.1.0 tag did not execute a line of the JAX path.

Adds a `test-jax` job installing `.[plot,jax]`.

Two choices worth explaining:

- **It runs the whole suite, not just `test_jax_backend.py`.** Having jax installed flips `JAX_AVAILABLE` and changes the path `Chain` takes, `jax_precompile` included, so the other test files cover more here than they do in the job without jax.
- **It cannot join the existing matrix.** The current jax declares `requires-python >= 3.12`, while the suite runs from 3.10, so adding the extra to the main job would break `3.10` and `3.11`. Hence a separate job on `['3.12', '3.13']`.

`publish` now needs `[test, test-jax]`, so a broken JAX backend stops a release rather than reaching PyPI.

No release: this is CI only, nothing in `src/` changes.

Locally, the difference this makes is 44 passed without the extra versus 61 with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JtYHFen3c3XseQAozpyuX